### PR TITLE
Introduce Metadata as an item of MetadataList

### DIFF
--- a/src/DownloadXML.php
+++ b/src/DownloadXML.php
@@ -109,8 +109,8 @@ class DownloadXML
      */
     protected function makePromises()
     {
-        foreach ($this->getMetadataList() as $data) {
-            $link = strval($data['urlXml'] ?? '');
+        foreach ($this->getMetadataList() as $metadata) {
+            $link = $metadata->get('urlXml');
             if ('' === $link) {
                 continue;
             }

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper;
+
+use InvalidArgumentException;
+
+class Metadata
+{
+    /** @var array */
+    private $data;
+
+    public function __construct(string $uuid, array $data = [])
+    {
+        if ('' === $uuid) {
+            throw new InvalidArgumentException('UUID cannot be empty');
+        }
+        $this->data = ['uuid' => $uuid] + $data;
+    }
+
+    public function uuid(): string
+    {
+        return $this->data['uuid'];
+    }
+
+    public function get(string $key): string
+    {
+        return strval($this->data[$key] ?? '');
+    }
+
+    public function has(string $key): bool
+    {
+        return isset($this->data[$key]);
+    }
+}

--- a/src/MetadataList.php
+++ b/src/MetadataList.php
@@ -6,22 +6,26 @@ namespace PhpCfdi\CfdiSatScraper;
 
 class MetadataList implements \Countable, \IteratorAggregate
 {
-    /**
-     * @var array<string, array>
-     */
+    /** @var Metadata[] */
     private $list = [];
 
-    /**
-     * @param array<string, array> $list
-     */
+    /** @param Metadata[] $list */
     public function __construct(array $list)
     {
-        $this->list = $list;
+        $this->list = [];
+        foreach ($list as $metadata) {
+            if (! $metadata instanceof Metadata) {
+                continue;
+            }
+            $this->list[$metadata->uuid()] = $metadata;
+        }
     }
 
     public function merge(self $list): self
     {
-        return new self(array_merge($this->list, $list->list));
+        $new = new self([]);
+        $new->list = array_merge($this->list, $list->list);
+        return $new;
     }
 
     public function has(string $uuid): bool
@@ -29,12 +33,12 @@ class MetadataList implements \Countable, \IteratorAggregate
         return isset($this->list[$uuid]);
     }
 
-    public function find(string $uuid): ?array
+    public function find(string $uuid): ?Metadata
     {
         return $this->list[$uuid] ?? null;
     }
 
-    public function get(string $uuid): array
+    public function get(string $uuid): Metadata
     {
         $values = $this->find($uuid);
         if (null === $values) {
@@ -44,7 +48,7 @@ class MetadataList implements \Countable, \IteratorAggregate
     }
 
     /**
-     * @return \Traversable|array<string, array>
+     * @return \Traversable|Metadata[]
      */
     public function getIterator()
     {

--- a/src/QueryResolver.php
+++ b/src/QueryResolver.php
@@ -56,9 +56,7 @@ class QueryResolver
         $htmlSearch = $this->consumeSearch($url, $post);
 
         // extract data from resolved search
-        $extractor = new MetadataExtractor();
-        $data = $extractor->extract($htmlSearch);
-        return new MetadataList($data);
+        return (new MetadataExtractor())->extract($htmlSearch);
     }
 
     protected function consumeFormPage(string $url): string

--- a/tests/FakesFactory/Fakes.php
+++ b/tests/FakesFactory/Fakes.php
@@ -6,6 +6,7 @@ namespace PhpCfdi\CfdiSatScraper\Tests\FakesFactory;
 
 use Faker\Factory as FakerFactory;
 use Faker\Generator as FakerGenerator;
+use PhpCfdi\CfdiSatScraper\Metadata;
 use PhpCfdi\CfdiSatScraper\MetadataList;
 
 class Fakes
@@ -15,11 +16,9 @@ class Fakes
         return FakerFactory::create();
     }
 
-    public function doMetadata(): array
+    public function doMetadata(): Metadata
     {
-        return [
-            'uuid' => $this->faker()->uuid,
-        ];
+        return new Metadata($this->faker()->uuid);
     }
 
     public function doMetadataList(int $howMany): MetadataList

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit;
+
+use PhpCfdi\CfdiSatScraper\Metadata;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+
+class MetadataTest extends TestCase
+{
+    public function testCreateAndRetrieveData(): void
+    {
+        $uuid = $this->fakes()->faker()->uuid;
+        $item = new Metadata($uuid, ['bar' => 'x-bar', 'foo' => 'x-foo']);
+        $this->assertSame($uuid, $item->uuid());
+        $this->assertSame('x-foo', $item->get('foo'));
+        $this->assertSame('', $item->get('xee'), 'non existent data must return empty string');
+    }
+
+    public function testUuidPassedOnConstructorOverridesUuidOnData(): void
+    {
+        $uuid = $this->fakes()->faker()->uuid;
+        $item = new Metadata($uuid, ['uuid' => 'x-foo']);
+        $this->assertSame($uuid, $item->uuid());
+        $this->assertSame($uuid, $item->get('uuid'));
+    }
+
+    public function testUuidPassedOnConstructorWorksAsAnyOtherData(): void
+    {
+        $uuid = $this->fakes()->faker()->uuid;
+        $item = new Metadata($uuid);
+        $this->assertSame($uuid, $item->get('uuid'));
+        $this->assertTrue($item->has('uuid'));
+    }
+
+    public function testCreatingWithEmptyUuidThrowsInvalidArgumentException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('UUID cannot be empty');
+        new Metadata('');
+    }
+
+    public function testCloningPreserveContents(): void
+    {
+        $base = new Metadata($this->fakes()->faker()->uuid, ['foo' => 'x-foo', 'bar' => 'x-bar']);
+        $clon = clone $base;
+        $this->assertEquals($base, $clon);
+        $this->assertNotSame($base, $clon);
+    }
+}

--- a/tests/_files/fake-to-extract-metadata-missing-uuid.html
+++ b/tests/_files/fake-to-extract-metadata-missing-uuid.html
@@ -1,0 +1,74 @@
+<html lang="es">
+    <body>
+        <table id="ctl00_MainContent_tblResult">
+            <tr>
+                <th><span>Acciones</span></th>
+                <th><span>Folio Fiscal</span></th>
+                <th><span>RFC Emisor</span></th>
+                <th><span>Nombre o Razón Social del Emisor</span></th>
+                <th><span>RFC Receptor</span></th>
+                <th><span>Nombre o Razón Social del Receptor</span></th>
+                <th><span>Fecha de Emisión</span></th>
+                <th><span>Fecha de Certificación</span></th>
+                <th><span>PAC que Certificó</span></th>
+                <th><span>Total</span></th>
+                <th><span>Efecto del Comprobante</span></th>
+                <th><span>Estatus de cancelación</span></th>
+                <th><span>Estado del Comprobante</span></th>
+                <th><span>Estatus de Proceso de Cancelación</span></th>
+                <th><span>Fecha de Proceso de Cancelación</span></th>
+            </tr>
+            <tr>
+                <td style="width:14.2%;">...</td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:385px;">B97262E5-704C-4BF7-AE26-000000000001</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">BSM970519DU8</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:350px;">BANCO SANTANDER MEXICO, SA INSTITUCION DE BANCA MULTIPLE, GRUPO FINANCIERO SANTANDER MEXICO</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">AUAC920422D38</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:350px;">CESAR RENE AGUILERA ARREOLA</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">2019-03-31T02:04:46</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">2019-03-31T02:05:15</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">INT020124V62</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">$0.00</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Ingreso</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;">Cancelable sin aceptación</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+            </tr>
+            <tr>
+                <td style="width:14.2%;">...</td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:385px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">BSM970519DU8</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:350px;">BANCO SANTANDER MEXICO, SA INSTITUCION DE BANCA MULTIPLE, GRUPO FINANCIERO SANTANDER MEXICO</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">AUAC920422D38</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:350px;">CESAR RENE AGUILERA ARREOLA</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">2019-03-31T02:04:46</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">2019-03-31T02:05:15</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">INT020124V62</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">$0.00</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Ingreso</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;">Cancelable sin aceptación</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+            </tr>
+            <tr>
+                <td style="width:14.2%;">...</td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:385px;">B97262E5-704C-4BF7-AE26-000000000002</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">BSM970519DU8</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:350px;">BANCO SANTANDER MEXICO, SA INSTITUCION DE BANCA MULTIPLE, GRUPO FINANCIERO SANTANDER MEXICO</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">AUAC920422D38</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:350px;">CESAR RENE AGUILERA ARREOLA</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">2019-03-31T02:04:46</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">2019-03-31T02:05:15</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">INT020124V62</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:150px;">$0.00</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Ingreso</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;">Cancelable sin aceptación</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+            </tr>
+        </table>
+    </body>
+</html>


### PR DESCRIPTION
- Add Metadata (immutable) object to store extracted tuples, this is a major improvement in memory and avoid to copy arrays all around
- Refactor MetadataExtractor, MetadataList, DownloadXML & QueryResolver to work with previous structure
- Increase code coverage

See full list of commits to review refactor