### PR TITLE
Test and refactor ParserFormatSat

### DIFF
--- a/src/Internal/ParserFormatSAT.php
+++ b/src/Internal/ParserFormatSAT.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\CfdiSatScraper;
+namespace PhpCfdi\CfdiSatScraper\Internal;
 
 /**
  * This class is a helper to parse that incredibly weird responses from SAT that contains internal
@@ -11,6 +11,8 @@ namespace PhpCfdi\CfdiSatScraper;
  * format: |value-length|field-type|field-name|value
  * example: |3|hiddenField|__FOO|foo|0|hiddenField|__EMPTY||16|hiddenField|__BAR|0123456789abcdef|
  * contents: __FOO: foo, __EMPTY: , __BAR: 0123456789abcdef
+ *
+ * @internal
  */
 class ParserFormatSAT
 {

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -32,11 +32,6 @@ class ParserFormatSAT
         $this->valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
     }
 
-    private function process(): void
-    {
-        $this->values = explode('|', $this->source);
-    }
-
     private function orderValues(): void
     {
         $this->sorted = [];
@@ -56,7 +51,7 @@ class ParserFormatSAT
      */
     public function getFormValues()
     {
-        $this->process();
+        $this->values = explode('|', $this->source);
         $this->orderValues();
 
         return $this->items;

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -29,7 +29,7 @@ class ParserFormatSAT
         $this->source = $source;
         $this->values = [];
         $this->items = [];
-        $this->valids = ['EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
+        $this->valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
     }
 
     private function process(): void

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -25,20 +25,22 @@ class ParserFormatSAT
     }
 
     /**
-     * @return array
+     * Parse and retrieve only the preconfigured valid keys
+     *
+     * @return array<string, string>
      */
-    public function getFormValues()
+    public function getFormValues(): array
     {
-        $values = explode('|', $this->source);
+        // format is: |value-length|field-type|field-name|value
+
+        $values = explode('|', ltrim($this->source, '|'));
+        $length = count($values);
 
         $items = [];
-        foreach (range(0, count($values) - 1) as $index) {
-            $item = $values[$index];
-            if (in_array($item, $this->valids)) {
-                $name = $item;
-                $index += 1;
-                $item = $values[$index];
-                $items[$name] = $item;
+        for ($index = 0; $index < $length; $index = $index + 4) {
+            $fieldName = $values[$index + 2] ?? '';
+            if (in_array($fieldName, $this->valids, true)) {
+                $items[$fieldName] = $values[$index + 3] ?? '';
             }
         }
 

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -12,7 +12,7 @@ class ParserFormatSAT
     public $source;
 
     /** @var string[] array of field names to filter */
-    private $valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
+    private const FILTER_KEYS = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
 
     /**
      * ParserFormatSAT constructor.
@@ -39,7 +39,7 @@ class ParserFormatSAT
         $items = [];
         for ($index = 0; $index < $length; $index = $index + 4) {
             $fieldName = $values[$index + 2] ?? '';
-            if (in_array($fieldName, $this->valids, true)) {
+            if (in_array($fieldName, self::FILTER_KEYS, true)) {
                 $items[$fieldName] = $values[$index + 3] ?? '';
             }
         }

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper;
 
 /**
- * Class ParserFormatSAT.
+ * This class is a helper to parse that incredibly weird responses from SAT that contains internal
+ * information in a pipe delimited list.
+ *
+ * format: |value-length|field-type|field-name|value
+ * example: |3|hiddenField|__FOO|foo|0|hiddenField|__EMPTY||16|hiddenField|__BAR|0123456789abcdef|
+ * contents: __FOO: foo, __EMPTY: , __BAR: 0123456789abcdef
  */
 class ParserFormatSAT
 {

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -9,31 +9,20 @@ namespace PhpCfdi\CfdiSatScraper;
  */
 class ParserFormatSAT
 {
-    public $source;
-
     /** @var string[] array of field names to filter */
     private const FILTER_KEYS = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
 
     /**
-     * ParserFormatSAT constructor.
+     * Parse source and retrieve only the preconfigured valid keys
      *
-     * @param $source
-     */
-    public function __construct($source)
-    {
-        $this->source = $source;
-    }
-
-    /**
-     * Parse and retrieve only the preconfigured valid keys
-     *
+     * @param string $source
      * @return array<string, string>
      */
-    public function getFormValues(): array
+    public function getFormValues(string $source): array
     {
         // format is: |value-length|field-type|field-name|value
 
-        $values = explode('|', ltrim($this->source, '|'));
+        $values = explode('|', ltrim($source, '|'));
         $length = count($values);
 
         $items = [];

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -11,8 +11,6 @@ class ParserFormatSAT
 {
     public $source;
 
-    public $items;
-
     public $valids;
 
     /**
@@ -23,7 +21,6 @@ class ParserFormatSAT
     public function __construct($source)
     {
         $this->source = $source;
-        $this->items = [];
         $this->valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
     }
 
@@ -34,16 +31,17 @@ class ParserFormatSAT
     {
         $values = explode('|', $this->source);
 
+        $items = [];
         foreach (range(0, count($values) - 1) as $index) {
             $item = $values[$index];
             if (in_array($item, $this->valids)) {
                 $name = $item;
                 $index += 1;
                 $item = $values[$index];
-                $this->items[$name] = $item;
+                $items[$name] = $item;
             }
         }
 
-        return $this->items;
+        return $items;
     }
 }

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -11,7 +11,8 @@ class ParserFormatSAT
 {
     public $source;
 
-    public $valids;
+    /** @var string[] array of field names to filter */
+    private $valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
 
     /**
      * ParserFormatSAT constructor.
@@ -21,7 +22,6 @@ class ParserFormatSAT
     public function __construct($source)
     {
         $this->source = $source;
-        $this->valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
     }
 
     /**

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -15,8 +15,6 @@ class ParserFormatSAT
 
     public $valids;
 
-    public $sorted;
-
     /**
      * ParserFormatSAT constructor.
      *
@@ -36,7 +34,6 @@ class ParserFormatSAT
     {
         $values = explode('|', $this->source);
 
-        $this->sorted = [];
         foreach (range(0, count($values) - 1) as $index) {
             $item = $values[$index];
             if (in_array($item, $this->valids)) {

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -32,8 +32,13 @@ class ParserFormatSAT
         $this->valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
     }
 
-    private function orderValues(): void
+    /**
+     * @return array
+     */
+    public function getFormValues()
     {
+        $this->values = explode('|', $this->source);
+
         $this->sorted = [];
         foreach (range(0, count($this->values) - 1) as $index) {
             $item = $this->values[$index];
@@ -44,15 +49,6 @@ class ParserFormatSAT
                 $this->items[$name] = $item;
             }
         }
-    }
-
-    /**
-     * @return array
-     */
-    public function getFormValues()
-    {
-        $this->values = explode('|', $this->source);
-        $this->orderValues();
 
         return $this->items;
     }

--- a/src/ParserFormatSAT.php
+++ b/src/ParserFormatSAT.php
@@ -11,8 +11,6 @@ class ParserFormatSAT
 {
     public $source;
 
-    public $values;
-
     public $items;
 
     public $valids;
@@ -27,7 +25,6 @@ class ParserFormatSAT
     public function __construct($source)
     {
         $this->source = $source;
-        $this->values = [];
         $this->items = [];
         $this->valids = ['__EVENTTARGET', '__EVENTARGUMENT', '__LASTFOCUS', '__VIEWSTATE'];
     }
@@ -37,15 +34,15 @@ class ParserFormatSAT
      */
     public function getFormValues()
     {
-        $this->values = explode('|', $this->source);
+        $values = explode('|', $this->source);
 
         $this->sorted = [];
-        foreach (range(0, count($this->values) - 1) as $index) {
-            $item = $this->values[$index];
+        foreach (range(0, count($values) - 1) as $index) {
+            $item = $values[$index];
             if (in_array($item, $this->valids)) {
                 $name = $item;
                 $index += 1;
-                $item = $this->values[$index];
+                $item = $values[$index];
                 $this->items[$name] = $item;
             }
         }

--- a/src/QueryResolver.php
+++ b/src/QueryResolver.php
@@ -10,6 +10,7 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters;
 use PhpCfdi\CfdiSatScraper\Filters\FiltersIssued;
 use PhpCfdi\CfdiSatScraper\Filters\FiltersReceived;
 use PhpCfdi\CfdiSatScraper\Filters\Options\DownloadTypesOption;
+use PhpCfdi\CfdiSatScraper\Internal\ParserFormatSAT;
 
 class QueryResolver
 {

--- a/src/QueryResolver.php
+++ b/src/QueryResolver.php
@@ -55,7 +55,7 @@ class QueryResolver
         $html = $this->consumeSearch($url, $post);
 
         // consume search using search filters
-        $post = array_merge($inputs, $filters->getRequestFilters(), (new ParserFormatSAT($html))->getFormValues());
+        $post = array_merge($inputs, $filters->getRequestFilters(), (new ParserFormatSAT())->getFormValues($html));
         $htmlSearch = $this->consumeSearch($url, $post);
 
         // extract data from resolved search

--- a/tests/Unit/Internal/ParserFormatSatTest.php
+++ b/tests/Unit/Internal/ParserFormatSatTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\CfdiSatScraper\Tests\Unit;
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Internal;
 
-use PhpCfdi\CfdiSatScraper\ParserFormatSAT;
+use PhpCfdi\CfdiSatScraper\Internal\ParserFormatSAT;
 use PhpCfdi\CfdiSatScraper\Tests\TestCase;
 
 final class ParserFormatSatTest extends TestCase

--- a/tests/Unit/ParserFormatSatTest.php
+++ b/tests/Unit/ParserFormatSatTest.php
@@ -11,8 +11,8 @@ final class ParserFormatSatTest extends TestCase
 {
     public function testWithEmptySource(): void
     {
-        $parser = new ParserFormatSAT('');
-        $this->assertSame([], $parser->getFormValues());
+        $parser = new ParserFormatSAT();
+        $this->assertSame([], $parser->getFormValues(''));
     }
 
     public function testWithExactSource(): void
@@ -24,8 +24,8 @@ final class ParserFormatSatTest extends TestCase
             '__VIEWSTATE' => 'x-event-viewstate',
         ];
         $source = $this->buildFakeSourceData($data);
-        $parser = new ParserFormatSAT($source);
-        $this->assertSame($data, $parser->getFormValues());
+        $parser = new ParserFormatSAT();
+        $this->assertSame($data, $parser->getFormValues($source));
     }
 
     public function testWithSourceMissingKeys(): void
@@ -37,9 +37,9 @@ final class ParserFormatSatTest extends TestCase
             '__VIEWSTATE' => 'x-event-viewstate',
         ];
         $source = $this->buildFakeSourceData($data);
-        $parser = new ParserFormatSAT($source);
+        $parser = new ParserFormatSAT();
         unset($data['__FOO_BAR']);
-        $this->assertSame($data, $parser->getFormValues());
+        $this->assertSame($data, $parser->getFormValues($source));
     }
 
     public function testWithSourceOtherKeys(): void
@@ -50,8 +50,8 @@ final class ParserFormatSatTest extends TestCase
             '__VIEWSTATE' => 'x-event-viewstate',
         ];
         $source = $this->buildFakeSourceData($data);
-        $parser = new ParserFormatSAT($source);
-        $this->assertSame($data, $parser->getFormValues());
+        $parser = new ParserFormatSAT();
+        $this->assertSame($data, $parser->getFormValues($source));
     }
 
     public function buildFakeSourceData(array $values): string

--- a/tests/Unit/ParserFormatSatTest.php
+++ b/tests/Unit/ParserFormatSatTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit;
+
+use PhpCfdi\CfdiSatScraper\ParserFormatSAT;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+
+final class ParserFormatSatTest extends TestCase
+{
+    public function testWithEmptySource(): void
+    {
+        $parser = new ParserFormatSAT('');
+        $this->assertSame([], $parser->getFormValues());
+    }
+
+    public function testWithExactSource(): void
+    {
+        $data = [
+            '__EVENTTARGET' => 'x-event-target',
+            '__EVENTARGUMENT' => 'x-event-argument',
+            '__LASTFOCUS' => 'x-last-focus',
+            '__VIEWSTATE' => 'x-event-viewstate',
+        ];
+        $source = $this->buildFakeSourceData($data);
+        $parser = new ParserFormatSAT($source);
+        $this->assertSame($data, $parser->getFormValues());
+    }
+
+    public function testWithSourceMissingKeys(): void
+    {
+        $data = [
+            '__EVENTTARGET' => 'x-event-target',
+            '__EVENTARGUMENT' => 'x-event-argument',
+            '__FOO_BAR' => 'foo-bar',
+            '__VIEWSTATE' => 'x-event-viewstate',
+        ];
+        $source = $this->buildFakeSourceData($data);
+        $parser = new ParserFormatSAT($source);
+        unset($data['__FOO_BAR']);
+        $this->assertSame($data, $parser->getFormValues());
+    }
+
+    public function testWithSourceOtherKeys(): void
+    {
+        $data = [
+            '__EVENTTARGET' => 'x-event-target',
+            '__EVENTARGUMENT' => 'x-event-argument',
+            '__VIEWSTATE' => 'x-event-viewstate',
+        ];
+        $source = $this->buildFakeSourceData($data);
+        $parser = new ParserFormatSAT($source);
+        $this->assertSame($data, $parser->getFormValues());
+    }
+
+    public function buildFakeSourceData(array $values): string
+    {
+        return implode('', array_map(function ($fieldName, $fieldValue): string {
+            return '|' . implode('|', [strlen($fieldValue), 'hiddenField', $fieldName, $fieldValue]);
+        }, array_keys($values), $values));
+    }
+}


### PR DESCRIPTION
The commits have a complete history of this change
summary: no need a constructor, things to parse are given as a parameter, understand format, simplify logic, add phpdoc, etc.
This class has been included on Internal namespace