### PR TITLE
Remove unused protected property BaseFilters::$uuid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
   - tools/php-cs-fixer fix --verbose --dry-run
   - tools/phpcs --colors -sp src/ tests/
   - vendor/bin/phpunit --testdox --verbose
+  - tools/phpstan analyze --level 5 --no-progress --verbose src/ tests/
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
         ],
         "dev:tests": [
             "@dev:check-style",
-            "vendor/bin/phpunit --verbose"
+            "vendor/bin/phpunit --verbose",
+            "tools/phpstan analyze --level 5 --no-progress --verbose src/ tests/"
         ]
     },
     "scripts-descriptions": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,3 @@
+parameters:
+    inferPrivatePropertyTypeFromConstructor: true
+

--- a/src/Captcha/Resolvers/DeCaptcherCaptchaResolver.php
+++ b/src/Captcha/Resolvers/DeCaptcherCaptchaResolver.php
@@ -21,17 +21,17 @@ class DeCaptcherCaptchaResolver implements CaptchaResolverInterface
     protected $client;
 
     /**
-     * @var
+     * @var string
      */
     protected $user;
 
     /**
-     * @var
+     * @var string
      */
     protected $password;
 
     /**
-     * @var
+     * @var string
      */
     protected $image;
 

--- a/src/Contracts/Filters.php
+++ b/src/Contracts/Filters.php
@@ -7,17 +7,17 @@ namespace PhpCfdi\CfdiSatScraper\Contracts;
 interface Filters
 {
     /**
-     * @return mixed
+     * @return array<string, string>
      */
     public function getFilters(): array;
 
     /**
-     * @return mixed
+     * @return array<string, string>
      */
     public function getInitialFilters(): array;
 
     /**
-     * @return mixed
+     * @return array<string, string>
      */
     public function getRequestFilters(): array;
 }

--- a/src/DownloadXML.php
+++ b/src/DownloadXML.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\CfdiSatScraper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\CookieJar;
 use GuzzleHttp\Promise\EachPromise;
-use Prophecy\Promise\PromiseInterface;
+use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**

--- a/src/Filters/BaseFilters.php
+++ b/src/Filters/BaseFilters.php
@@ -18,7 +18,7 @@ abstract class BaseFilters implements Filters
     protected $query;
 
     /**
-     * @var
+     * @var string
      */
     protected $uuid;
 
@@ -32,7 +32,7 @@ abstract class BaseFilters implements Filters
     }
 
     /**
-     * @param $uuid
+     * @param string $uuid
      *
      * @return BaseFilters
      */

--- a/src/Filters/BaseFilters.php
+++ b/src/Filters/BaseFilters.php
@@ -77,16 +77,6 @@ abstract class BaseFilters implements Filters
     }
 
     /**
-     * @return array
-     */
-    abstract public function getFilters(): array;
-
-    /**
-     * @return array
-     */
-    abstract public function getInitialFilters(): array;
-
-    /**
      * @return string
      */
     protected function getCentralFilter()

--- a/src/Filters/BaseFilters.php
+++ b/src/Filters/BaseFilters.php
@@ -18,29 +18,12 @@ abstract class BaseFilters implements Filters
     protected $query;
 
     /**
-     * @var string
-     */
-    protected $uuid;
-
-    /**
      * BaseFilters constructor.
      * @param Query $query
      */
     public function __construct(Query $query)
     {
         $this->query = $query;
-    }
-
-    /**
-     * @param string $uuid
-     *
-     * @return BaseFilters
-     */
-    public function setUuid($uuid): self
-    {
-        $this->uuid = $uuid;
-
-        return $this;
     }
 
     /**

--- a/src/Filters/BaseFilters.php
+++ b/src/Filters/BaseFilters.php
@@ -66,7 +66,7 @@ abstract class BaseFilters implements Filters
      */
     protected function getCentralFilter(): string
     {
-        if (! empty($this->query->getUuid())) {
+        if ($this->query->hasUuids()) {
             return 'RdoFolioFiscal';
         }
 

--- a/src/Filters/BaseFilters.php
+++ b/src/Filters/BaseFilters.php
@@ -77,11 +77,13 @@ abstract class BaseFilters implements Filters
     }
 
     /**
+     * Retrieve the CentralFilter data, if this query is about UUID then it is RdoFolioFiscal, else is RdoFechas
+     *
      * @return string
      */
-    protected function getCentralFilter()
+    protected function getCentralFilter(): string
     {
-        if (! empty($this->uuid)) {
+        if (! empty($this->query->getUuid())) {
             return 'RdoFolioFiscal';
         }
 

--- a/src/Filters/BaseFilters.php
+++ b/src/Filters/BaseFilters.php
@@ -69,9 +69,6 @@ abstract class BaseFilters implements Filters
         return $overrideFilters;
     }
 
-    /**
-     * @return array
-     */
     public function getRequestFilters(): array
     {
         $requestFilters = array_merge($this->getFilters(), $this->overrideDefaultFilters());

--- a/src/Filters/FiltersIssued.php
+++ b/src/Filters/FiltersIssued.php
@@ -11,9 +11,6 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters;
  */
 class FiltersIssued extends BaseFilters implements Filters
 {
-    /**
-     * @return array
-     */
     public function getFilters(): array
     {
         return [
@@ -53,9 +50,6 @@ class FiltersIssued extends BaseFilters implements Filters
         ];
     }
 
-    /**
-     * @return array
-     */
     public function getInitialFilters(): array
     {
         return [

--- a/src/Filters/FiltersReceived.php
+++ b/src/Filters/FiltersReceived.php
@@ -11,9 +11,6 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters;
  */
 class FiltersReceived extends BaseFilters implements Filters
 {
-    /**
-     * @return array
-     */
     public function getFilters(): array
     {
         return [
@@ -45,9 +42,6 @@ class FiltersReceived extends BaseFilters implements Filters
         ];
     }
 
-    /**
-     * @return array
-     */
     public function getInitialFilters(): array
     {
         return [

--- a/src/HtmlForm.php
+++ b/src/HtmlForm.php
@@ -66,8 +66,9 @@ class HtmlForm
     public function readAndGetValues(string $element): array
     {
         $data = [];
-        $elements = $this->crawler->filter("{$this->parentElement} > {$element}");
 
+        /** @var \DOMElement[] $elements */
+        $elements = $this->crawler->filter("{$this->parentElement} > {$element}");
         foreach ($elements as $element) {
             $data[$element->getAttribute('name')] = $element->getAttribute('value');
         }

--- a/src/HtmlForm.php
+++ b/src/HtmlForm.php
@@ -59,7 +59,7 @@ class HtmlForm
     }
 
     /**
-     * @param $element
+     * @param string $element
      *
      * @return array
      */

--- a/src/Query.php
+++ b/src/Query.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper;
 
-use Eclipxe\Enum\Enum;
-use PhpCfdi\CfdiSatScraper\Contracts\Filters\FilterOption;
+use DateTimeImmutable;
 use PhpCfdi\CfdiSatScraper\Contracts\Filters\Options\RfcOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\ComplementsOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\DownloadTypesOption;
@@ -14,46 +13,46 @@ use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
 class Query
 {
     /**
-     * @var \DateTime
+     * @var DateTimeImmutable
      */
     protected $startDate;
 
     /**
-     * @var \DateTime
+     * @var DateTimeImmutable
      */
     protected $endDate;
 
     /**
-     * @var RfcOption
+     * @var RfcOption|null
      */
     protected $rfc;
 
     /**
-     * @var array
+     * @var string[]|null
      */
     protected $uuid;
 
     /**
-     * @var Enum
+     * @var ComplementsOption
      */
     protected $complement;
 
     /**
-     * @var Enum
+     * @var StatesVoucherOption
      */
     protected $stateVoucher;
 
     /**
-     * @var Enum
+     * @var DownloadTypesOption
      */
     protected $downloadType;
 
     /**
      * Query constructor.
-     * @param \DateTimeImmutable $startDate
-     * @param \DateTimeImmutable $endDate
+     * @param DateTimeImmutable $startDate
+     * @param DateTimeImmutable $endDate
      */
-    public function __construct(\DateTimeImmutable $startDate, \DateTimeImmutable $endDate)
+    public function __construct(DateTimeImmutable $startDate, DateTimeImmutable $endDate)
     {
         if ($endDate < $startDate) {
             throw new \InvalidArgumentException('La fecha final no puede ser menor a la inicial');
@@ -67,18 +66,18 @@ class Query
     }
 
     /**
-     * @return \DateTimeImmutable
+     * @return DateTimeImmutable
      */
-    public function getStartDate(): \DateTimeImmutable
+    public function getStartDate(): DateTimeImmutable
     {
         return $this->startDate;
     }
 
     /**
-     * @param \DateTimeImmutable $startDate
+     * @param DateTimeImmutable $startDate
      * @return Query
      */
-    public function setStartDate(\DateTimeImmutable $startDate): self
+    public function setStartDate(DateTimeImmutable $startDate): self
     {
         $this->startDate = $startDate;
 
@@ -86,18 +85,18 @@ class Query
     }
 
     /**
-     * @return \DateTimeImmutable
+     * @return DateTimeImmutable
      */
-    public function getEndDate(): \DateTimeImmutable
+    public function getEndDate(): DateTimeImmutable
     {
         return $this->endDate;
     }
 
     /**
-     * @param \DateTimeImmutable $endDate
+     * @param DateTimeImmutable $endDate
      * @return Query
      */
-    public function setEndDate(\DateTimeImmutable $endDate): self
+    public function setEndDate(DateTimeImmutable $endDate): self
     {
         $this->endDate = $endDate;
 
@@ -113,7 +112,7 @@ class Query
     }
 
     /**
-     * @param array $uuid
+     * @param string[] $uuid
      * @return Query
      */
     public function setUuid(array $uuid): self
@@ -124,7 +123,7 @@ class Query
     }
 
     /**
-     * @return FilterOption|null
+     * @return string[]|null
      */
     public function getUuid(): ?array
     {

--- a/src/Query.php
+++ b/src/Query.php
@@ -122,6 +122,11 @@ class Query
         return $this;
     }
 
+    public function hasUuids(): bool
+    {
+        return (! empty($this->uuid));
+    }
+
     /**
      * @return string[]|null
      */

--- a/tests/Unit/MetadataListTest.php
+++ b/tests/Unit/MetadataListTest.php
@@ -90,7 +90,9 @@ final class MetadataListTest extends TestCase
 
     public function testOnlyContainsMetadataEvenWhenNullIsPassed(): void
     {
-        $list = new MetadataList([null]);
+        /** @var Metadata[] $source */
+        $source = [null];
+        $list = new MetadataList($source);
         $this->assertCount(0, $list);
     }
 


### PR DESCRIPTION
The property $uuid was made to detect the central filter, it can be set from query and not using an internal property