### PR TITLE
Code analysis, integration tests & httplogger on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - tools/php-cs-fixer fix --verbose --dry-run
   - tools/phpcs --colors -sp src/ tests/
   - vendor/bin/phpunit tests/ --testdox --no-interaction --verbose
-  - tools/phpstan analyze --level 5 --no-progress --verbose src/ tests/
+  - tools/phpstan analyze --level 8 --no-progress --verbose src/ tests/
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - tools/php-cs-fixer fix --verbose --dry-run
   - tools/phpcs --colors -sp src/ tests/
   - vendor/bin/phpunit tests/ --testdox --no-interaction --verbose
-  - tools/phpstan analyze --level 8 --no-progress --verbose src/ tests/
+  - tools/phpstan analyze --level max --no-progress --verbose src/ tests/
 
 notifications:
   email:

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "dev:tests": [
             "@dev:check-style",
             "vendor/bin/phpunit tests/Unit/",
-            "tools/phpstan analyze --level 5 --no-progress --verbose src/ tests/"
+            "tools/phpstan analyze --level 8 --no-progress --verbose src/ tests/"
         ]
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
         "dev:tests": [
             "@dev:check-style",
             "vendor/bin/phpunit tests/Unit/",
-            "tools/phpstan analyze --level 8 --no-progress --verbose src/ tests/"
+            "tools/phpstan analyze --level max --no-progress --verbose src/ tests/"
         ]
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -31,13 +31,13 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-dom": "*",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "^6.3",
         "symfony/dom-crawler": "^4.2|^5.0",
         "symfony/css-selector": "^4.2|^5.0",
         "eclipxe/enum": "^0.2.0"
     },
     "require-dev": {
-        "ext-json": "*",
         "symfony/dotenv": "^4.2|^5.0",
         "fzaninotto/faker": "^1.8",
         "phpunit/phpunit": "^8.5"

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "eclipxe/enum": "^0.2.0"
     },
     "require-dev": {
+        "ext-iconv": "*",
         "symfony/dotenv": "^4.2|^5.0",
         "fzaninotto/faker": "^1.8",
         "phpunit/phpunit": "^8.5"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,7 +8,6 @@
     - Todos los puntos de entrada deben tener phpdoc.
 - Entorno de desarrollo:
     - CodeStyle: Subir a PSR-12.
-    - PhpStan: Nivel máximo
 
 ## Wishlist
 
@@ -19,6 +18,10 @@
 - Implementar `rector`.
 
 ## Realizadas
+
+- 2020-02-11:
+    - Entorno de desarrollo: PhpStan: Nivel máximo, aunque se está omitiendo la verificación
+      `checkMissingIterableValueType`, corregirla será bastante complejo por las dependencias.
 
 - 2020-01-29:
     - PHP Minimal version to PHP 7.2 (cambios en código, no solamente en composer.json)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,4 @@
 parameters:
     inferPrivatePropertyTypeFromConstructor: true
+    checkMissingIterableValueType: false
 

--- a/src/Captcha/CaptchaBase64Extractor.php
+++ b/src/Captcha/CaptchaBase64Extractor.php
@@ -8,54 +8,26 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class CaptchaBase64Extractor
 {
-    /** @var string */
-    private $html;
+    const DEFAULT_SELECTOR = '#divCaptcha > img';
 
     /**
-     * CaptchaBase64Extractor constructor.
-     * @param string $html
+     * @param string $htmlSource
+     * @param string $selector
+     * @return string
      */
-    public function __construct(string $html)
+    public function retrieve(string $htmlSource, string $selector = ''): string
     {
-        $this->html = $html;
-    }
+        $selector = $selector ?: self::DEFAULT_SELECTOR;
 
-    /**
-     * @param string|null $selector
-     * @return Crawler
-     */
-    private function findImg(?string $selector): Crawler
-    {
-        $selector = $selector ?? '#divCaptcha > img';
-
-        $img = (new Crawler($this->html))
-            ->filter($selector);
-
-        if (0 === $img->count()) {
+        $images = (new Crawler($htmlSource))->filter($selector);
+        if (0 === $images->count()) {
             throw new \RuntimeException('Captcha was not found');
         }
+        $firstImage = $images->first();
 
-        return $img->first();
-    }
+        $srcContent = strval($firstImage->attr('src'));
+        $srcContent = str_replace('data:image/jpeg;base64,', '', $srcContent);
 
-    /**
-     * @param string|null $selector
-     * @return string
-     */
-    private function getSrc(?string $selector): string
-    {
-        $img = $this->findImg($selector);
-        $src = $img->attr('src');
-
-        return str_replace('data:image/jpeg;base64,', '', $src);
-    }
-
-    /**
-     * @param string|null $selector
-     * @return string
-     */
-    public function retrieve(?string $selector = null): string
-    {
-        return $this->getSrc($selector);
+        return $srcContent;
     }
 }

--- a/src/Captcha/CaptchaBase64Extractor.php
+++ b/src/Captcha/CaptchaBase64Extractor.php
@@ -8,7 +8,7 @@ use Symfony\Component\DomCrawler\Crawler;
 
 class CaptchaBase64Extractor
 {
-    const DEFAULT_SELECTOR = '#divCaptcha > img';
+    public const DEFAULT_SELECTOR = '#divCaptcha > img';
 
     /**
      * @param string $htmlSource

--- a/src/Captcha/Resolvers/DeCaptcherCaptchaResolver.php
+++ b/src/Captcha/Resolvers/DeCaptcherCaptchaResolver.php
@@ -81,6 +81,6 @@ class DeCaptcherCaptchaResolver implements CaptchaResolverInterface
             return '';
         }
 
-        return (string)trim(end($parts));
+        return trim((string) end($parts));
     }
 }

--- a/src/Contracts/Filters/FilterOption.php
+++ b/src/Contracts/Filters/FilterOption.php
@@ -7,11 +7,13 @@ namespace PhpCfdi\CfdiSatScraper\Contracts\Filters;
 interface FilterOption
 {
     /**
+     * Returns the input name of the filter
      * @return string
      */
     public function nameIndex(): string;
 
     /**
+     * Return the input value of the filter
      * @return string
      */
     public function value(): string;

--- a/src/DownloadXML.php
+++ b/src/DownloadXML.php
@@ -133,7 +133,7 @@ class DownloadXML
         $partsOfContentDisposition = explode(';', $contentDisposition);
         $fileName = str_replace('filename=', '', $partsOfContentDisposition[1] ?? '');
 
-        return ! empty($fileName) ? $fileName : uniqid() . '.xml';
+        return strtolower(! empty($fileName) ? $fileName : uniqid() . '.xml');
     }
 
     /**

--- a/src/Filters/BaseFilters.php
+++ b/src/Filters/BaseFilters.php
@@ -28,7 +28,7 @@ abstract class BaseFilters implements Filters
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public function overrideDefaultFilters(): array
     {

--- a/src/Filters/Options/ComplementsOption.php
+++ b/src/Filters/Options/ComplementsOption.php
@@ -95,9 +95,6 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters\FilterOption;
  */
 class ComplementsOption extends Enum implements FilterOption
 {
-    /**
-     * @return array
-     */
     protected static function overrideValues(): array
     {
         return [
@@ -144,9 +141,6 @@ class ComplementsOption extends Enum implements FilterOption
         ];
     }
 
-    /**
-     * @return string
-     */
     public function nameIndex(): string
     {
         return 'ctl00$MainContent$ddlComplementos';

--- a/src/Filters/Options/DownloadTypesOption.php
+++ b/src/Filters/Options/DownloadTypesOption.php
@@ -8,7 +8,6 @@ use Eclipxe\Enum\Enum;
 use PhpCfdi\CfdiSatScraper\Contracts\Filters\FilterOption;
 
 /**
- *
  * @method static self recibidos()
  * @method static self emitidos()
  *
@@ -17,9 +16,6 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters\FilterOption;
  */
 class DownloadTypesOption extends Enum implements FilterOption
 {
-    /**
-     * @return array
-     */
     protected static function overrideValues(): array
     {
         return [
@@ -28,9 +24,6 @@ class DownloadTypesOption extends Enum implements FilterOption
         ];
     }
 
-    /**
-     * @return string
-     */
     public function nameIndex(): string
     {
         return 'ctl00$MainContent$TipoBusqueda';

--- a/src/Filters/Options/RfcOption.php
+++ b/src/Filters/Options/RfcOption.php
@@ -8,31 +8,19 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters\FilterOption;
 
 class RfcOption implements FilterOption
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
-    /**
-     * Rfc constructor.
-     * @param string $rfc
-     */
     public function __construct(string $rfc)
     {
         $this->value = $rfc;
     }
 
-    /**
-     * @return string
-     */
     public function nameIndex(): string
     {
         return 'ctl00$MainContent$TxtRfcReceptor';
     }
 
-    /**
-     * @return string
-     */
     public function value(): string
     {
         return $this->value;

--- a/src/Filters/Options/StatesVoucherOption.php
+++ b/src/Filters/Options/StatesVoucherOption.php
@@ -21,9 +21,6 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters\FilterOption;
  */
 class StatesVoucherOption extends Enum implements FilterOption
 {
-    /**
-     * @return array
-     */
     protected static function overrideValues(): array
     {
         return [
@@ -33,9 +30,6 @@ class StatesVoucherOption extends Enum implements FilterOption
         ];
     }
 
-    /**
-     * @return string
-     */
     public function nameIndex(): string
     {
         return 'ctl00$MainContent$DdlEstadoComprobante';

--- a/src/Filters/Options/UuidOption.php
+++ b/src/Filters/Options/UuidOption.php
@@ -19,7 +19,7 @@ class UuidOption implements FilterOption
      */
     public function __construct(string $uuid)
     {
-        $this->value = $uuid;
+        $this->value = strtolower($uuid);
     }
 
     /**

--- a/src/Filters/Options/UuidOption.php
+++ b/src/Filters/Options/UuidOption.php
@@ -8,31 +8,19 @@ use PhpCfdi\CfdiSatScraper\Contracts\Filters\FilterOption;
 
 class UuidOption implements FilterOption
 {
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $value;
 
-    /**
-     * RfcReceptor constructor.
-     * @param string $uuid
-     */
     public function __construct(string $uuid)
     {
         $this->value = strtolower($uuid);
     }
 
-    /**
-     * @return string
-     */
     public function nameIndex(): string
     {
         return 'ctl00$MainContent$TxtUUID';
     }
 
-    /**
-     * @return string
-     */
     public function value(): string
     {
         return $this->value;

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper;
 
 use InvalidArgumentException;
+use JsonSerializable;
 
-class Metadata
+class Metadata implements JsonSerializable
 {
     /** @var array */
     private $data;
@@ -32,5 +33,11 @@ class Metadata
     public function has(string $key): bool
     {
         return isset($this->data[$key]);
+    }
+
+    /** @return array<string, string> */
+    public function jsonSerialize(): array
+    {
+        return $this->data;
     }
 }

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -16,7 +16,7 @@ class Metadata
         if ('' === $uuid) {
             throw new InvalidArgumentException('UUID cannot be empty');
         }
-        $this->data = ['uuid' => $uuid] + $data;
+        $this->data = ['uuid' => strtolower($uuid)] + $data;
     }
 
     public function uuid(): string

--- a/src/MetadataList.php
+++ b/src/MetadataList.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\CfdiSatScraper;
 /**
  * @implements \IteratorAggregate<Metadata>
  */
-class MetadataList implements \Countable, \IteratorAggregate
+class MetadataList implements \Countable, \IteratorAggregate, \JsonSerializable
 {
     /** @var Metadata[] */
     private $list = [];
@@ -61,5 +61,11 @@ class MetadataList implements \Countable, \IteratorAggregate
     public function count(): int
     {
         return count($this->list);
+    }
+
+    /** @return array<string, Metadata> */
+    public function jsonSerialize(): array
+    {
+        return $this->list;
     }
 }

--- a/src/MetadataList.php
+++ b/src/MetadataList.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper;
 
+/**
+ * @implements \IteratorAggregate<Metadata>
+ */
 class MetadataList implements \Countable, \IteratorAggregate
 {
     /** @var Metadata[] */

--- a/src/MetadataList.php
+++ b/src/MetadataList.php
@@ -33,12 +33,12 @@ class MetadataList implements \Countable, \IteratorAggregate
 
     public function has(string $uuid): bool
     {
-        return isset($this->list[$uuid]);
+        return isset($this->list[strtolower($uuid)]);
     }
 
     public function find(string $uuid): ?Metadata
     {
-        return $this->list[$uuid] ?? null;
+        return $this->list[strtolower($uuid)] ?? null;
     }
 
     public function get(string $uuid): Metadata

--- a/src/SATScraper.php
+++ b/src/SATScraper.php
@@ -387,7 +387,7 @@ class SATScraper
         return $this->createMetadataDownloader()->downloadByDateTime($query);
     }
 
-    protected function parseInputs($html): array
+    protected function parseInputs(string $html): array
     {
         $htmlForm = new HtmlForm($html, 'form');
         $inputs = $htmlForm->getFormValues();

--- a/src/SATScraper.php
+++ b/src/SATScraper.php
@@ -209,8 +209,8 @@ class SATScraper
     protected function requestCaptchaImage(): string
     {
         $html = $this->consumeLoginPage();
-        $captchaBase64Extractor = new CaptchaBase64Extractor($html);
-        $imageBase64 = $captchaBase64Extractor->retrieve();
+        $captchaBase64Extractor = new CaptchaBase64Extractor();
+        $imageBase64 = $captchaBase64Extractor->retrieve($html);
         if ('' === $imageBase64) {
             throw new \RuntimeException('Unable to extract the base64 image from login page');
         }

--- a/tests/.env-example
+++ b/tests/.env-example
@@ -4,6 +4,9 @@
 SAT_AUTH_RFC=""
 SAT_AUTH_CIEC=""
 
+# location of the http log files, use something as build/httplogs, if empty no log files will be created
+SAT_HTTP_LOGFILE="build/httplogs"
+
 # captcha resolver: "console" or "decaptcher"
 CAPTCHA_RESOLVER="console"
 

--- a/tests/.env-example
+++ b/tests/.env-example
@@ -4,8 +4,9 @@
 SAT_AUTH_RFC=""
 SAT_AUTH_CIEC=""
 
-# location of the http log files, use something as build/httplogs, if empty no log files will be created
-SAT_HTTP_LOGFILE="build/httplogs"
+# location of the http log files, use something as build/httplogs,
+# if empty no log files will be created, if start with '/' is an absolute path, otherwise is relative to project folder
+SAT_HTTPDUMP_FOLDER="build/httplogs"
 
 # captcha resolver: "console" or "decaptcher"
 CAPTCHA_RESOLVER="console"

--- a/tests/Integration/Factory.php
+++ b/tests/Integration/Factory.php
@@ -80,7 +80,7 @@ class Factory
 
     public function createGuzzleClient(): Client
     {
-        $container = new HttpLogger(strval(getenv('SAT_HTTP_LOGFILE')));
+        $container = new HttpLogger(strval(getenv('SAT_HTTPDUMP_FOLDER')));
         $stack = HandlerStack::create();
         $stack->push(Middleware::history($container));
         return new Client(['handler' => $stack]);

--- a/tests/Integration/Factory.php
+++ b/tests/Integration/Factory.php
@@ -6,6 +6,8 @@ namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Cookie\FileCookieJar;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use PhpCfdi\CfdiSatScraper\Captcha\Resolvers\ConsoleCaptchaResolver;
 use PhpCfdi\CfdiSatScraper\Captcha\Resolvers\DeCaptcherCaptchaResolver;
 use PhpCfdi\CfdiSatScraper\Contracts\CaptchaResolverInterface;
@@ -72,7 +74,16 @@ class Factory
         }
 
         $cookieFile = __DIR__ . '/../../build/cookie-' . strtolower($rfc) . '.json';
-        return new SATScraper($rfc, $ciec, new Client(), new FileCookieJar($cookieFile), static::createCaptchaResolver());
+        $client = $this->createGuzzleClient();
+        return new SATScraper($rfc, $ciec, $client, new FileCookieJar($cookieFile), static::createCaptchaResolver());
+    }
+
+    public function createGuzzleClient(): Client
+    {
+        $container = new HttpLogger(strval(getenv('SAT_HTTP_LOGFILE')));
+        $stack = HandlerStack::create();
+        $stack->push(Middleware::history($container));
+        return new Client(['handler' => $stack]);
     }
 
     public function createRepository(string $filename): Repository

--- a/tests/Integration/HttpLogger.php
+++ b/tests/Integration/HttpLogger.php
@@ -19,9 +19,11 @@ class HttpLogger extends ArrayObject
     public function __construct(string $destinationDir)
     {
         parent::__construct();
-        if ('' !== $destinationDir) {
-            $this->destinationDir = $destinationDir;
+        // if is not empty and is not an absolute path, prepend project dir
+        if ('' !== $destinationDir && ! in_array(substr($destinationDir, 0, 1), ['/', '\\'], true)) {
+            $destinationDir = dirname(__DIR__, 3) . '/' . $destinationDir;
         }
+        $this->destinationDir = $destinationDir;
     }
 
     /**

--- a/tests/Integration/HttpLogger.php
+++ b/tests/Integration/HttpLogger.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
+
+use ArrayObject;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * @extends ArrayObject<int, array>
+ */
+class HttpLogger extends ArrayObject
+{
+    /** @var string */
+    private $destinationDir;
+
+    public function __construct(string $destinationDir)
+    {
+        parent::__construct();
+        if ('' !== $destinationDir) {
+            $this->destinationDir = $destinationDir;
+        }
+    }
+
+    /**
+     * @param mixed $entry
+     */
+    public function append($entry): void
+    {
+        $this->write($entry);
+        parent::append($entry);
+    }
+
+    /**
+     * @param int|string|null $index
+     * @param mixed $entry
+     */
+    public function offsetSet($index, $entry): void
+    {
+        if (null === $index) {
+            $this->write($entry);
+        }
+        parent::offsetSet($index, $entry);
+    }
+
+    /**
+     * @param mixed $entry
+     * @throws \Exception
+     */
+    public function write($entry): void
+    {
+        if (! is_array($entry)) {
+            return;
+        }
+        if ('' === $this->destinationDir) {
+            return;
+        }
+        if (! file_exists($this->destinationDir)) {
+            mkdir($this->destinationDir, 0755, true);
+        }
+        /** @var RequestInterface $request */
+        $request = $entry['request'];
+        /** @var ResponseInterface $response */
+        $response = $entry['response'];
+        $time = new \DateTimeImmutable();
+        $file = sprintf(
+            '%s/%s.%06d-%s-%s.json',
+            $this->destinationDir,
+            $time->format('c'),
+            $time->format('u'),
+            strtolower($request->getMethod()),
+            $this->slugify((string) sprintf('%s%s', $request->getUri()->getHost(), $request->getUri()->getPath()))
+        );
+        file_put_contents($file, $this->entryToJson($request, $response), FILE_APPEND);
+    }
+
+    public function slugify(string $text): string
+    {
+        $text = (string) preg_replace('~[^\pL\d]+~u', '-', $text);
+        $text = (string) iconv('utf-8', 'us-ascii//TRANSLIT', $text);
+        $text = (string) preg_replace('~[^-\w]+~', '', $text);
+        $text = trim($text, '-');
+        $text = (string) preg_replace('~-+~', '-', $text);
+        $text = strtolower($text);
+        return $text;
+    }
+
+    public function entryToJson(RequestInterface $request, ResponseInterface $response): string
+    {
+        $json = json_encode(
+            [
+                    'uri' => sprintf('%s: %s', $request->getMethod(), (string)$request->getUri()),
+                    'request' => [
+                        'headers' => $request->getHeaders(),
+                        'body' => $this->bodyToVars((string)$request->getBody()),
+                    ],
+                    'response' => [
+                        'headers' => $response->getHeaders(),
+                        'body' => $this->bodyToVars((string)$request->getBody()),
+                    ],
+                ],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_LINE_TERMINATORS
+        ) . PHP_EOL;
+        $request->getBody()->rewind();
+        $response->getBody()->rewind();
+        return $json;
+    }
+
+    public function bodyToVars(string $body): array
+    {
+        $variables = [];
+        parse_str($body, $variables);
+        return $variables;
+    }
+}

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -62,11 +62,14 @@ class IntegrationTestCase extends TestCase
     {
         /** @var RepositoryItem $item */
         foreach ($repository as $item) {
-            $metadata = $list->get($item->getUuid());
-            self::assertNotNull($metadata, "The metadata list does not contain the UUID {$item->getUuid()}");
+            $metadata = $list->find($item->getUuid());
+            if (null === $metadata) {
+                self::fail("The metadata list does not contain the UUID {$item->getUuid()}");
+                return;
+            }
             self::assertRepositoryItemEqualsMetadata($item, $metadata);
         }
-        self::assertCount(count($repository), $list, 'The metadata list has not the same quantity of elements');
+        self::assertSame(count($repository), count($list), 'The metadata list has not the same quantity of elements');
     }
 
     public static function assertRepositoryItemEqualsMetadata(RepositoryItem $item, Metadata $metadata): void

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -98,8 +98,8 @@ class IntegrationTestCase extends TestCase
         /** @var DOMAttr $uuidAttr */
         $uuidAttr = $list->item(0);
         self::assertSame(
-            $expectedUuid,
-            $uuidAttr->value,
+            strtolower($expectedUuid),
+            strtolower($uuidAttr->value),
             sprintf('The UUID from the XML CFDI %s is not the same as expected %s', $uuidAttr->value, $expectedUuid)
         );
     }

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -62,7 +62,7 @@ class IntegrationTestCase extends TestCase
     {
         /** @var RepositoryItem $item */
         foreach ($repository as $item) {
-            $metadata = $list->find($item->getUuid());
+            $metadata = $list->get($item->getUuid());
             self::assertNotNull($metadata, "The metadata list does not contain the UUID {$item->getUuid()}");
             self::assertRepositoryItemEqualsMetadata($item, $metadata);
         }
@@ -88,7 +88,7 @@ class IntegrationTestCase extends TestCase
         $xpath = new DOMXPath($document);
         $xpath->registerNamespace('cfdi', 'http://www.sat.gob.mx/cfd/3');
         $xpath->registerNamespace('tfd', 'http://www.sat.gob.mx/TimbreFiscalDigital');
-        /** @var DOMNodeList|false $list */
+        /** @var DOMNodeList<DOMAttr>|false $list */
         $list = $xpath->query('/cfdi:Comprobante/cfdi:Complemento/tfd:TimbreFiscalDigital/@UUID');
         if (false === $list) {
             $list = new DOMNodeList();

--- a/tests/Integration/Repository.php
+++ b/tests/Integration/Repository.php
@@ -8,6 +8,7 @@ use ArrayIterator;
 use Countable;
 use DateTimeImmutable;
 use IteratorAggregate;
+use JsonSerializable;
 use PhpCfdi\CfdiSatScraper\Filters\Options\DownloadTypesOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
 
@@ -15,7 +16,7 @@ use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
  * Class Repository to be able to perform tests
  * @implements IteratorAggregate<RepositoryItem>
  */
-class Repository implements Countable, IteratorAggregate
+class Repository implements Countable, IteratorAggregate, JsonSerializable
 {
     /** @var RepositoryItem[] */
     private $items;
@@ -137,5 +138,10 @@ class Repository implements Countable, IteratorAggregate
     public function getIterator()
     {
         return new ArrayIterator($this->items);
+    }
+
+    public function jsonSerialize(): array
+    {
+        return iterator_to_array($this->getIterator());
     }
 }

--- a/tests/Integration/Repository.php
+++ b/tests/Integration/Repository.php
@@ -13,6 +13,7 @@ use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
 
 /**
  * Class Repository to be able to perform tests
+ * @implements IteratorAggregate<RepositoryItem>
  */
 class Repository implements Countable, IteratorAggregate
 {

--- a/tests/Integration/RepositoryItem.php
+++ b/tests/Integration/RepositoryItem.php
@@ -22,7 +22,7 @@ class RepositoryItem
 
     public function __construct(string $uuid, DateTimeImmutable $date, string $state, string $type)
     {
-        $this->uuid = $uuid;
+        $this->uuid = strtolower($uuid);
         $this->date = $date;
         $this->type = strtoupper(substr($type, 0, 1));
         $this->state = strtoupper(substr($state, 0, 1));

--- a/tests/Integration/RepositoryItem.php
+++ b/tests/Integration/RepositoryItem.php
@@ -28,7 +28,7 @@ class RepositoryItem
         $this->state = strtoupper(substr($state, 0, 1));
     }
 
-    public static function fromArray(array $item)
+    public static function fromArray(array $item): self
     {
         return new self(
             strval($item['uuid'] ?? ''),

--- a/tests/Integration/RepositoryItem.php
+++ b/tests/Integration/RepositoryItem.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
 
 use DateTimeImmutable;
+use JsonSerializable;
 
-class RepositoryItem
+class RepositoryItem implements JsonSerializable
 {
     /** @var string */
     private $uuid;
@@ -56,5 +57,10 @@ class RepositoryItem
     public function getState(): string
     {
         return $this->state;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
     }
 }

--- a/tests/Integration/RetrieveByCfdiStateTest.php
+++ b/tests/Integration/RetrieveByCfdiStateTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
+
+use PhpCfdi\CfdiSatScraper\Filters\Options\DownloadTypesOption;
+use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
+use PhpCfdi\CfdiSatScraper\Query;
+
+class RetrieveByCfdiStateTest extends IntegrationTestCase
+{
+    /**
+     * @param DownloadTypesOption $downloadType
+     * @dataProvider providerEmitidosRecibidos
+     */
+    public function testRetrieveByCfdiStateCancelados(DownloadTypesOption $downloadType): void
+    {
+        $state = StatesVoucherOption::cancelados();
+        $typeText = $this->getDownloadTypeText($downloadType);
+        $repository = $this->getRepository()->filterByType($downloadType);
+        $repository = $repository->filterByState($state);
+        if (0 === $repository->count()) {
+            $this->markTestSkipped(
+                sprintf('The repository does not have CFDI %s with state Cancelado', $typeText)
+            );
+        }
+
+        $scraper = $this->getSatScraper();
+        $query = (new Query($repository->getSinceDate(), $repository->getUntilDate()))
+            ->setDownloadType($downloadType)
+            ->setStateVoucher($state);
+        $list = $scraper->downloadByDateTime($query);
+
+        $this->assertRepositoryEqualsMetadataList($repository, $list);
+    }
+
+    /**
+     * @param DownloadTypesOption $downloadType
+     * @dataProvider providerEmitidosRecibidos
+     */
+    public function testRetrieveByCfdiStateVigentes(DownloadTypesOption $downloadType): void
+    {
+        $state = StatesVoucherOption::vigentes();
+        $typeText = $this->getDownloadTypeText($downloadType);
+        $repository = $this->getRepository()->filterByType($downloadType);
+        $repository = $repository->filterByState($state);
+        if (0 === $repository->count()) {
+            $this->markTestSkipped(
+                sprintf('The repository does not have CFDI %s with state Vigente', $typeText)
+            );
+        }
+
+        $scraper = $this->getSatScraper();
+        $query = (new Query($repository->getSinceDate(), $repository->getUntilDate()))
+            ->setDownloadType($downloadType)
+            ->setStateVoucher($state);
+        $list = $scraper->downloadByDateTime($query);
+
+        $this->assertRepositoryEqualsMetadataList($repository, $list);
+    }
+}

--- a/tests/Integration/RetrieveByUuidTest.php
+++ b/tests/Integration/RetrieveByUuidTest.php
@@ -45,8 +45,8 @@ class RetrieveByUuidTest extends IntegrationTestCase
         $tempDir = sys_get_temp_dir();
         $scraper->downloader()->setMetadataList($list)->saveTo($tempDir);
         foreach ($uuids as $uuid) {
-            $filename = sprintf('%s/%s.xml', $tempDir, $uuid);
-            $this->assertFileExists($filename, sprintf('The file to download the uuid %s does not exists: %s', $uuid, $filename));
+            $filename = strtolower(sprintf('%s/%s.xml', $tempDir, $uuid));
+            $this->assertFileExists($filename, sprintf('The cfdi file with uuid %s does not exists: %s', $uuid, $filename));
             $this->assertCfdiHasUuid($uuid, file_get_contents($filename) ?: '');
         }
     }

--- a/tests/Unit/CaptchaBase64ExtractorTest.php
+++ b/tests/Unit/CaptchaBase64ExtractorTest.php
@@ -15,8 +15,8 @@ final class CaptchaBase64ExtractorTest extends TestCase
         $html .= '<img src="data:image/jpeg;base64,test">';
         $html .= '</div>';
 
-        $captchaExtractor = new CaptchaBase64Extractor($html);
-        $this->assertEquals('test', $captchaExtractor->retrieve());
+        $captchaExtractor = new CaptchaBase64Extractor();
+        $this->assertEquals('test', $captchaExtractor->retrieve($html));
     }
 
     public function testRetrieveWhenDefaultElementNotExists(): void
@@ -25,10 +25,10 @@ final class CaptchaBase64ExtractorTest extends TestCase
         $html .= '<img src="data:image/jpeg;base64,test">';
         $html .= '</div>';
 
-        $captchaExtractor = new CaptchaBase64Extractor($html);
+        $captchaExtractor = new CaptchaBase64Extractor();
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Captcha was not found');
-        $captchaExtractor->retrieve();
+        $captchaExtractor->retrieve($html);
     }
 
     public function testRetrieveBySelectorWhenElementExists(): void
@@ -37,7 +37,7 @@ final class CaptchaBase64ExtractorTest extends TestCase
         $html .= '<img src="data:image/jpeg;base64,test">';
         $html .= '</div>';
 
-        $captchaExtractor = new CaptchaBase64Extractor($html);
-        $this->assertEquals('test', $captchaExtractor->retrieve('#captcha > img'));
+        $captchaExtractor = new CaptchaBase64Extractor();
+        $this->assertEquals('test', $captchaExtractor->retrieve($html, '#captcha > img'));
     }
 }

--- a/tests/Unit/FakeQueryResolver.php
+++ b/tests/Unit/FakeQueryResolver.php
@@ -10,8 +10,10 @@ use PhpCfdi\CfdiSatScraper\QueryResolver;
 
 final class FakeQueryResolver extends QueryResolver
 {
+    /** @var array */
     private $fakeMoments = [];
 
+    /** @var array */
     public $resolveCalls = [];
 
     /** @noinspection PhpMissingParentConstructorInspection */

--- a/tests/Unit/MetadataExtractorTest.php
+++ b/tests/Unit/MetadataExtractorTest.php
@@ -109,7 +109,7 @@ final class MetadataExtractorTest extends TestCase
         $data = $extractor->extract($sample);
         $this->assertCount(1, $data);
 
-        $expectedUuid = 'B97262E5-704C-4BF7-AE26-9174FEF04D63';
+        $expectedUuid = 'b97262e5-704c-4bf7-ae26-9174fef04d63';
 
         $expectedData = [
             $expectedUuid => [

--- a/tests/Unit/MetadataListTest.php
+++ b/tests/Unit/MetadataListTest.php
@@ -113,6 +113,6 @@ final class MetadataListTest extends TestCase
             return new Metadata($uuid);
         }, $uuids);
         $contents = array_combine($uuids, $contents);
-        return $contents;
+        return $contents ?: [];
     }
 }

--- a/tests/Unit/QueryTest.php
+++ b/tests/Unit/QueryTest.php
@@ -7,6 +7,7 @@ namespace PhpCfdi\CfdiSatScraper\Tests\Unit;
 use PhpCfdi\CfdiSatScraper\Filters\Options\ComplementsOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\DownloadTypesOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\RfcOption;
+use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
 use PhpCfdi\CfdiSatScraper\Query;
 use PhpCfdi\CfdiSatScraper\Tests\TestCase;
 
@@ -94,5 +95,25 @@ final class QueryTest extends TestCase
         ];
 
         $this->assertEquals($expected, $splitted);
+    }
+
+    public function testSplitByDaysPreserveOtherFilters(): void
+    {
+        // this options are not the default
+        $downloadType = DownloadTypesOption::emitidos();
+        $complement = ComplementsOption::comercioExterior11();
+        $stateVoucher = StatesVoucherOption::cancelados();
+
+        $lowerBound = new \DateTimeImmutable('2019-01-13 14:15:16');
+        $upperBound = new \DateTimeImmutable('2019-01-15 18:19:20');
+        $query = new Query($lowerBound, $upperBound);
+        $query->setDownloadType($downloadType);
+        $query->setComplement($complement);
+        $query->setStateVoucher($stateVoucher);
+        foreach ($query->splitByDays() as $current) {
+            $this->assertEquals($downloadType, $current->getDownloadType());
+            $this->assertEquals($complement, $current->getComplement());
+            $this->assertEquals($stateVoucher, $current->getStateVoucher());
+        }
     }
 }

--- a/tests/generate-repository.php
+++ b/tests/generate-repository.php
@@ -83,7 +83,7 @@ exit(call_user_func(new class() {
             'date' => $metadata->get('fechaEmision'),
             'type' => $metadata->get('rfcEmisor') === $this->rfc ? 'E' : 'R',
             'state' => $metadata->get('estadoComprobante'),
-        ]);
+        ]) ?: '';
     }
 
     public function printHelp(): void


### PR DESCRIPTION
- The phpstan analysis level has been increased from 5 to 8 (max) but disabling `checkMissingIterableValueType`.
- Changed parameter of `SATScraper::parseInputs(mixed): array` to `SATScraper::parseInputs(string): array`
- Refactor `CaptchaBase64Extractor`: collapse private methods into `retrieve`(the public one), also, receive the html source in the `retrieve` method instead of `__constructor`.
- Implements `JsonSerializable` for `MetadataList` and `Metadata`.
- Use UUIDs always in lowercase
- Introduce on integration tests `HttpLogger` and environment variable `SAT_HTTP_LOGFILE` to dump http transactions into json files.
- Add integration tests about to retrieve CFDI by state (cancelado/vigente)