### PR TITLE
Rename \RuntimeException to SplRuntimeException

### DIFF
--- a/src/Exceptions/LoginException.php
+++ b/src/Exceptions/LoginException.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
 use PhpCfdi\CfdiSatScraper\SatSessionData;
-use RuntimeException;
+use RuntimeException as SplRuntimeException;
 use Throwable;
 
 /**
  * The LoginException defines a problem on registering to the SAT platform with specific credentials.
  * It contains the SAT session data, retrieved contents and posted data.
  */
-class LoginException extends RuntimeException implements SatException
+class LoginException extends SplRuntimeException implements SatException
 {
     /** @var SatSessionData */
     private $sessionData;

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
+use RuntimeException as SplRuntimeException;
 use Throwable;
 
-class RuntimeException extends \RuntimeException implements SatException
+class RuntimeException extends SplRuntimeException implements SatException
 {
     protected function __construct(string $message, Throwable $previous = null)
     {

--- a/src/Exceptions/SatHttpGatewayException.php
+++ b/src/Exceptions/SatHttpGatewayException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
-use RuntimeException;
+use RuntimeException as SplRuntimeException;
 use Throwable;
 
 /**
@@ -15,7 +15,7 @@ use Throwable;
  * @see SatHttpGatewayClientException
  * @see SatHttpGatewayResponseException
  */
-abstract class SatHttpGatewayException extends RuntimeException implements SatException
+abstract class SatHttpGatewayException extends SplRuntimeException implements SatException
 {
     /** @var string */
     private $url;

--- a/src/Exceptions/XmlDownloadError.php
+++ b/src/Exceptions/XmlDownloadError.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
-use RuntimeException;
+use RuntimeException as SplRuntimeException;
 use Throwable;
 
 /**
@@ -16,7 +16,7 @@ use Throwable;
  * @see XmlDownloadResponseError
  * @see XmlDownloadRequestExceptionError
  */
-class XmlDownloadError extends RuntimeException implements SatException
+class XmlDownloadError extends SplRuntimeException implements SatException
 {
     /** @var string */
     private $uuid;


### PR DESCRIPTION
Avoid conflicts as there is a RuntimeException class in the namespace \PhpCfdi\CfdiSatScraper\Exceptions