### PR TITLE
Corregir el build, roto por phpstan version 0.12.55

### DIFF
--- a/develop/install-development-tools
+++ b/develop/install-development-tools
@@ -1,25 +1,82 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
 
-if [ ! -f composer.json ]; then
-    echo "The composer.json file is not found, you could not be running this command on the correct folder"
-    exit 1
-fi
+# install-development-tools
+# Optional environment variables:
+#   TOOLS_DIR: where tools will be installed, defaults to "tools"
+#
+# Version: 0.0.20201110
+# Author: Carlos C Soto
+#
+# This scripts install a set of development tools and install them on a directory
+# The tools must be available on GitHub
+# The tool must be a single file
+# The online tool version is extracted from GitHub HTTP Location header
+# The current version is stored on a .tool-name.version file
 
-TOOLS_DIR=tools
-
-function install_from_github() {
-  local destination="${TOOLS_DIR}/${3}"
-  if [ -f "$destination" ]; then
-    rm "$destination"
-  fi
-  wget "https://github.com/${1}/releases/latest/download/${2}" -O "${TOOLS_DIR}/${3}"
-  chmod +x "$destination"
+function github_online_version() {
+    curl -s -I "$1" | grep -i ^location | awk '{print $2}' | xargs dirname | xargs basename
 }
 
-rm -rf "$TOOLS_DIR"
+function install_on() {
+    local github_url="${1}"
+    local destination="${2}"
+    local version_file="${3}"
+    local version_content="${4}"
+
+    curl --location --output "$destination" "$github_url"
+    echo "$version_content" >"$version_file"
+    chmod +x "$destination"
+}
+
+function upgrade_from_github() {
+    local github_url="${1}"
+    local destination="${2}"
+    local version_file="${3}"
+    local current_version="$(cat "$version_file")"
+    local online_version="$(github_online_version "$github_url")"
+
+    echo -n "Upgrade $destination: "
+    if [ "$current_version" == "$online_version" ]; then
+        echo "already on $current_version"
+        return 0
+    fi
+
+    echo -n "from $current_version to $online_version ... "
+    install_on "$github_url" "$destination" "$version_file" "$online_version"
+    echo "OK"
+    return 0
+}
+
+function install_from_github() {
+    local github_url="${1}"
+    local destination="${2}"
+    local version_file="${3}"
+    local current_version="$(github_online_version "$github_url")"
+
+    echo -n "Install $destination: version $current_version ... "
+    install_on "$github_url" "$destination" "$version_file" "$current_version"
+    echo "OK"
+    return 0
+}
+
+function install_upgrade() {
+    local destination="${3}"
+    local version_file="$(dirname "${3}")/.$(basename "${3}").version"
+    local github_url="https://github.com/${1}/releases/latest/download/${2}"
+
+    if [ -f "$destination" -a -f "$version_file" ]; then
+        upgrade_from_github "$github_url" "$destination" "$version_file" && return 0
+    fi
+
+    install_from_github "$github_url" "$destination" "$version_file" && return 0
+
+    return 1;
+}
+
+TOOLS_DIR="${TOOLS_DIR:-tools}"
 mkdir -p "$TOOLS_DIR"
 
-install_from_github FriendsOfPHP/PHP-CS-Fixer php-cs-fixer.phar php-cs-fixer
-install_from_github squizlabs/PHP_CodeSniffer phpcbf.phar phpcbf
-install_from_github squizlabs/PHP_CodeSniffer phpcs.phar phpcs
-install_from_github phpstan/phpstan phpstan.phar phpstan
+install_upgrade FriendsOfPHP/PHP-CS-Fixer php-cs-fixer.phar "${TOOLS_DIR}/php-cs-fixer"
+install_upgrade squizlabs/PHP_CodeSniffer phpcbf.phar "${TOOLS_DIR}/phpcbf"
+install_upgrade squizlabs/PHP_CodeSniffer phpcs.phar "${TOOLS_DIR}/phpcs"
+install_upgrade phpstan/phpstan phpstan.phar "${TOOLS_DIR}/phpstan"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,14 @@ que nombraremos así: ` Breaking . Feature . Fix `, donde:
 **Importante:** Las reglas de SEMVER no aplican si estás usando una rama (por ejemplo `master-dev`)
 o estás usando una versión cero (por ejemplo `0.18.4`).
 
+## UNRELEASED 2020-10-14
+
+Este cambio no afecta la versión liberada y no requiere de un nuevo release.
+
+- La construcción en Travis-CI se rompió porque PHPStan version 0.12.55 ya entiende las estructuras de control
+  de PHPUnit, por lo que sabe que el código subsecuente es código muerto. Se corrigieron las pruebas con problemas.
+- Se actualizó la herramienta `develop/install-development-tools`
+
 ## Version 1.0.1
 
 - Se actualizan dependencias:

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -9,7 +9,6 @@ use DOMAttr;
 use DOMDocument;
 use DOMNodeList;
 use DOMXPath;
-use InvalidArgumentException;
 use PhpCfdi\CfdiSatScraper\Filters\DownloadType;
 use PhpCfdi\CfdiSatScraper\Metadata;
 use PhpCfdi\CfdiSatScraper\MetadataList;
@@ -33,23 +32,23 @@ class IntegrationTestCase extends TestCase
         return static::$factory;
     }
 
+    /** @noinspection PhpInconsistentReturnPointsInspection PhpStorm does not understand PHPUnit control flow */
     protected function getSatScraper(): SatScraper
     {
         try {
             return $this->getFactory()->getSatScraper();
         } catch (Throwable $exception) {
-            $this->markTestSkipped($exception->getMessage()); // this will stop execution
-            throw new InvalidArgumentException('no satscraper', 0, $exception);
+            $this->markTestSkipped($exception->getMessage());
         }
     }
 
+    /** @noinspection PhpInconsistentReturnPointsInspection PhpStorm does not understand PHPUnit control flow */
     protected function getRepository(): Repository
     {
         try {
             return $this->getFactory()->getRepository();
         } catch (Throwable $exception) {
-            $this->markTestSkipped($exception->getMessage()); // this will stop execution
-            throw new InvalidArgumentException('no repository', 0, $exception);
+            $this->markTestSkipped($exception->getMessage());
         }
     }
 
@@ -68,7 +67,6 @@ class IntegrationTestCase extends TestCase
             $metadata = $list->find($item->getUuid());
             if (null === $metadata) {
                 self::fail("The metadata list does not contain the UUID {$item->getUuid()}");
-                return;
             }
             self::assertRepositoryItemEqualsMetadata($item, $metadata);
         }


### PR DESCRIPTION
Este cambio no afecta la versión liberada y no requiere de un nuevo release.

- La construcción en Travis-CI se rompió porque PHPStan version 0.12.55 ya entiende las estructuras de control
  de PHPUnit, por lo que sabe que el código subsecuente es código muerto. Se corrigieron las pruebas con problemas.
- Se actualizó la herramienta `develop/install-development-tools`