### PR TITLE
Build improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,3 +71,4 @@ jobs:
         with:
           cli-args: "--format=php-clover build/coverage-clover.xml"
         if: ${{ matrix.php-versions == '8.0' }}
+        continue-on-error: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta librería sin temor a romper tu aplicación.
 
+## Cambios aún no liberados en una versión.
+
+- 2021-07-05: Tests: En las pruebas de `AntiCaptchaTinyClient` las respuestas preparadas no tenían correctamente
+  formados los `HEADERS`.
+- 2021-07-05: CI: Se permite que falle la subida del archivo de cobertura de código a Scrutinizer-CI.
+
 ## Version 2.1.0
 
 Se agrega la implementación para resolver el *captcha* en la clase `AntiCaptchaResolver`,

--- a/tests/Unit/Captcha/Resolvers/AntiCaptchaTinyClient/AntiCaptchaTinyClientTest.php
+++ b/tests/Unit/Captcha/Resolvers/AntiCaptchaTinyClient/AntiCaptchaTinyClientTest.php
@@ -48,7 +48,7 @@ final class AntiCaptchaTinyClientTest extends TestCase
      */
     public function createResponse(array $responseData): Response
     {
-        return new Response(200, ['Content-Type', 'application/json'], json_encode($responseData) ?: '');
+        return new Response(200, ['Content-Type' => 'application/json'], json_encode($responseData) ?: '');
     }
 
     public function testCreateTaskReturnId(): void


### PR DESCRIPTION
Fix PHPStan issue: On `AntiCaptchaTinyClientTest` the prepared responses had malformed headers.

Improvement: Allow fail on Upload to Scrutinizer-CI step.