### PR TITLE
Revisión general

### DIFF
--- a/docs/EjemploConsumo.md
+++ b/docs/EjemploConsumo.md
@@ -44,6 +44,9 @@ $ciecSessionManager = CiecSessionManager::create($rfc, $claveCiec, $captchaResol
 
 $satScraper = new SatScraper($ciecSessionManager, $gateway);
 
+$resourceDownloader = $satScraper->resourceDownloader(ResourceType::xml())
+    ->setConcurrency(20);
+
 $query = new QueryByFilters(new DateTimeImmutable('2019-12-01'), new DateTimeImmutable('2019-12-31'));
 $query->setDownloadType(DownloadType::recibidos()) // default: emitidos
     ->setStateVoucher(StatesVoucherOption::vigentes());   // default: todos
@@ -55,9 +58,7 @@ $list = $list->filterWithResourceLink(ResourceType::xml());
 printf("\nPero solamente %d contienen archivos XML", $list->count());
 while ($list->count() > 0) {
     printf("\nIntentando descargar %d archivos: ", $list->count());
-    $downloadedUuids = $satScraper->resourceDownloader(ResourceType::xml())
-        ->setMetadataList($list)
-        ->setConcurrency(20)
+    $downloadedUuids = $resourceDownloader->setMetadataList($list)
         ->saveTo($downloadsPath, true);
     printf("%d descargados: ", count($downloadedUuids));
     $list = $list->filterWithOutUuids($downloadedUuids);

--- a/docs/UPGRADE-2-3.md
+++ b/docs/UPGRADE-2-3.md
@@ -82,6 +82,13 @@ $onFiveHundred = new MyHandler();
 $satScraper = new SatScraper($sessionManager, $httpGateway, $onFiveHundred);
 ```
 
+## La clase `SatScraper` cumple con una interfaz
+
+La clase `SatScraper` pronto será marcada como final, y en esta versión se ha introducido la interfaz `SatScraperInterface`.
+
+Esta interfaz es útil para poder crear *mocks* y *stubs* para realizar pruebas unitarias en donde
+se esté implementando esta librería.
+
 ## Cambios técnicos
 
 Estos cambios son importantes solo si estás desarrollando o extendiendo esta librería.
@@ -93,6 +100,7 @@ Estos cambios son importantes solo si estás desarrollando o extendiendo esta li
 - Se han agregado nuevos métodos a `SatHttpGateway`.
 - Las constantes de URL han sido renombradas para mayor simplicidad.
 - Las clases `Enum` ahora son finales.
+- La clase `CaptchaBase64Extractor` ahora es interna y depende de `CaptchaImage`.
 
 Se ha cambiado el archivo de entorno de pruebas `tests/.env-example` agregando nuevas variables.
 Para correr los test de integración se recomienda configurar tanto la Clave CIEC como la FIEL.

--- a/src/Captcha/CaptchaBase64Extractor.php
+++ b/src/Captcha/CaptchaBase64Extractor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Captcha;
 
+use PhpCfdi\ImageCaptchaResolver\CaptchaImage;
 use RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -11,21 +12,16 @@ class CaptchaBase64Extractor
 {
     public const DEFAULT_SELECTOR = '#divCaptcha > img';
 
-    public function retrieve(string $htmlSource, string $selector = self::DEFAULT_SELECTOR): string
+    public function retrieveCaptchaImage(string $htmlSource, string $selector = self::DEFAULT_SELECTOR): CaptchaImage
     {
-        try {
-            $images = (new Crawler($htmlSource))->filter($selector);
-        } catch (RuntimeException $exception) {
-            return '';
-        }
+        $images = (new Crawler($htmlSource))->filter($selector);
+
         if (0 === $images->count()) {
-            return '';
+            throw new RuntimeException("Unable to find image using filter '$selector'");
         }
 
-        $firstImage = $images->first();
-        $srcContent = strval($firstImage->attr('src'));
-        $srcContent = str_replace('data:image/jpeg;base64,', '', $srcContent);
+        $imageSource = (string) $images->attr('src');
 
-        return $srcContent;
+        return CaptchaImage::newFromInlineHtml($imageSource);
     }
 }

--- a/src/Contracts/FilterOption.php
+++ b/src/Contracts/FilterOption.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Contracts;
 
 /**
- * This interface defines a class that has a name and value describing an option to be send to get the list of uuids
+ * This interface defines a class that has a name and value describing an option to be sent to get the list of uuids
  * on the html post form.
  */
 interface FilterOption

--- a/src/Contracts/ResourceDownloaderPromiseHandlerInterface.php
+++ b/src/Contracts/ResourceDownloaderPromiseHandlerInterface.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\ResponseInterface;
 interface ResourceDownloaderPromiseHandlerInterface
 {
     /**
-     * This method handles the each promise fulfilled event
+     * This method handles each promise fulfilled event
      *
      * @param ResponseInterface $response
      * @param string $uuid
@@ -18,7 +18,7 @@ interface ResourceDownloaderPromiseHandlerInterface
     public function promiseFulfilled(ResponseInterface $response, string $uuid);
 
     /**
-     * This method handles the each promise rejected event
+     * This method handles each promise rejected event
      *
      * @param mixed $reason
      * @param string $uuid
@@ -27,7 +27,7 @@ interface ResourceDownloaderPromiseHandlerInterface
     public function promiseRejected($reason, string $uuid);
 
     /**
-     * Return the list of succesfully processed UUIDS
+     * Return the list of successfully processed UUIDS
      *
      * @return string[]
      */

--- a/src/Contracts/ResourceFileNamerInterface.php
+++ b/src/Contracts/ResourceFileNamerInterface.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\CfdiSatScraper\Contracts;
 interface ResourceFileNamerInterface
 {
     /**
-     * A class that implements this interface should return the file name to store an specific uuid by resource type
+     * A class that implements this interface should return the file name to store a specific uuid by resource type
      *
      * @param string $uuid
      * @return string

--- a/src/Contracts/SatScraperInterface.php
+++ b/src/Contracts/SatScraperInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Contracts;
+
+use PhpCfdi\CfdiSatScraper\Exceptions\LoginException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Filters\DownloadType;
+use PhpCfdi\CfdiSatScraper\MetadataList;
+use PhpCfdi\CfdiSatScraper\QueryByFilters;
+use PhpCfdi\CfdiSatScraper\ResourceDownloader;
+use PhpCfdi\CfdiSatScraper\ResourceType;
+use PhpCfdi\CfdiSatScraper\SatScraper;
+
+interface SatScraperInterface
+{
+    /**
+     * Create a ResourceDownloader object with (optionally) a MetadataList.
+     * Use the ResourceDownloader to retrieve the CFDI related files.
+     *
+     * @param ResourceType|null $resourceType
+     * @param MetadataList|null $metadataList
+     * @param int $concurrency
+     * @return ResourceDownloader
+     */
+    public function resourceDownloader(
+        ResourceType $resourceType = null,
+        ?MetadataList $metadataList = null,
+        int $concurrency = ResourceDownloader::DEFAULT_CONCURRENCY
+    ): ResourceDownloader;
+
+    /**
+     * Initializes session on SAT
+     *
+     * @return SatScraper
+     * @throws LoginException if session is not alive
+     */
+    public function confirmSessionIsAlive(): SatScraper;
+
+    /**
+     * Retrieve the MetadataList using specific UUIDS to download
+     *
+     * @param string[] $uuids
+     * @param DownloadType $downloadType
+     * @return MetadataList
+     * @throws SatException on session or connection exception
+     */
+    public function listByUuids(array $uuids, DownloadType $downloadType): MetadataList;
+
+    /**
+     * Retrieve the MetadataList based on the query, but uses full days on dates (without time parts)
+     *
+     * @param QueryByFilters $query
+     * @return MetadataList
+     * @throws SatException on session or connection exception
+     */
+    public function listByPeriod(QueryByFilters $query): MetadataList;
+
+    /**
+     * Retrieve the MetadataList based on the query, but uses the period considering dates and times
+     *
+     * @param QueryByFilters $query
+     * @return MetadataList
+     * @throws SatException on session or connection exception
+     */
+    public function listByDateTime(QueryByFilters $query): MetadataList;
+}

--- a/src/Exceptions/LoginException.php
+++ b/src/Exceptions/LoginException.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
-use RuntimeException as SplRuntimeException;
 use Throwable;
 
 /**
  * The LoginException defines a problem on registering to the SAT platform with specific credentials.
  * It contains the SAT session data, retrieved contents and posted data.
  */
-abstract class LoginException extends SplRuntimeException implements SatException
+abstract class LoginException extends \RuntimeException implements SatException
 {
     /** @var string */
     private $contents;

--- a/src/Exceptions/ResourceDownloadError.php
+++ b/src/Exceptions/ResourceDownloadError.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
-use RuntimeException as SplRuntimeException;
 use Throwable;
 
 /**
@@ -16,7 +15,7 @@ use Throwable;
  * @see ResourceDownloadResponseError
  * @see ResourceDownloadRequestExceptionError
  */
-class ResourceDownloadError extends SplRuntimeException implements SatException
+class ResourceDownloadError extends \RuntimeException implements SatException
 {
     /** @var string */
     private $uuid;
@@ -27,7 +26,7 @@ class ResourceDownloadError extends SplRuntimeException implements SatException
     /**
      * ResourceDownloadError constructor.
      *
-     * If the reason is a Throwable and previous was not defined then it set up previous as reason
+     * If the reason is a Throwable and previous was not defined, then it set up previous as reason.
      *
      * @param string $message
      * @param string $uuid

--- a/src/Exceptions/ResourceDownloadRequestExceptionError.php
+++ b/src/Exceptions/ResourceDownloadRequestExceptionError.php
@@ -20,6 +20,6 @@ class ResourceDownloadRequestExceptionError extends ResourceDownloadError
 
     public static function onRequestException(RequestException $exception, string $uuid): self
     {
-        return new self('Download of CFDI %s fails when performing request', $uuid, $exception);
+        return new self(sprintf('Download of CFDI %s fails when performing request', $uuid), $uuid, $exception);
     }
 }

--- a/src/Exceptions/ResourceDownloadResponseError.php
+++ b/src/Exceptions/ResourceDownloadResponseError.php
@@ -48,6 +48,6 @@ class ResourceDownloadResponseError extends ResourceDownloadError
         if ($throwable instanceof self) {
             return $throwable;
         }
-        return new self("Download of CFDI $uuid was unable to handle fulfill", $uuid, $response, $throwable);
+        return new self(sprintf('Download of CFDI %s was unable to handle fulfill', $uuid), $uuid, $response, $throwable);
     }
 }

--- a/src/Exceptions/RuntimeException.php
+++ b/src/Exceptions/RuntimeException.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
-use RuntimeException as SplRuntimeException;
 use Throwable;
 
-class RuntimeException extends SplRuntimeException implements SatException
+class RuntimeException extends \RuntimeException implements SatException
 {
     protected function __construct(string $message, Throwable $previous = null)
     {
@@ -32,5 +31,10 @@ class RuntimeException extends SplRuntimeException implements SatException
     public static function unableToFilePutContents(string $destinationFile, Throwable $previous = null): self
     {
         return new self(sprintf('Unable to put contents on %s', $destinationFile), $previous);
+    }
+
+    public static function unableToFindCaptchaImage(string $selector): self
+    {
+        return new self(sprintf("Unable to find image using filter '%s'", $selector));
     }
 }

--- a/src/Exceptions/SatHttpGatewayClientException.php
+++ b/src/Exceptions/SatHttpGatewayClientException.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\CfdiSatScraper\Exceptions;
 use GuzzleHttp\Exception\GuzzleException;
 
 /**
- * This exception is thrown by SatHttpGateway and stores an http client exception GuzzleException
+ * This exception is thrown by SatHttpGateway and stores a http client exception GuzzleException
  *
  * @see GuzzleException
  */

--- a/src/Exceptions/SatHttpGatewayException.php
+++ b/src/Exceptions/SatHttpGatewayException.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
-use RuntimeException as SplRuntimeException;
 use Throwable;
 
 /**
@@ -15,7 +14,7 @@ use Throwable;
  * @see SatHttpGatewayClientException
  * @see SatHttpGatewayResponseException
  */
-abstract class SatHttpGatewayException extends SplRuntimeException implements SatException
+abstract class SatHttpGatewayException extends \RuntimeException implements SatException
 {
     /** @var string */
     private $url;

--- a/src/Filters/DownloadType.php
+++ b/src/Filters/DownloadType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Filters;
 
 use Eclipxe\Enum\Enum;
-use LogicException;
+use PhpCfdi\CfdiSatScraper\Exceptions\LogicException;
 use PhpCfdi\CfdiSatScraper\URLS;
 
 /**
@@ -28,7 +28,7 @@ final class DownloadType extends Enum
     {
         $url = self::URLS[$this->value()] ?? '';
         if ('' === $url) {
-            throw new LogicException(sprintf('Enum %s does not have the url for "%s"', self::class, $this->value()));
+            throw LogicException::generic(sprintf('Enum %s does not have the url for "%s"', self::class, $this->value()));
         }
         return $url;
     }

--- a/src/Filters/Options/StatesVoucherOption.php
+++ b/src/Filters/Options/StatesVoucherOption.php
@@ -8,7 +8,7 @@ use Eclipxe\Enum\Enum;
 use PhpCfdi\CfdiSatScraper\Contracts\FilterOption;
 
 /**
- * voucher state option enumerator: todos, cancelados & vigentes.
+ * Voucher state option enumerator: todos, cancelados & vigentes.
  *
  * @method static self todos()
  * @method static self cancelados()

--- a/src/Inputs/InputsByFilters.php
+++ b/src/Inputs/InputsByFilters.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use PhpCfdi\CfdiSatScraper\QueryByFilters;
 
 /**
- * @method QueryByFilters getQuery()
+ * @extends InputsGeneric<QueryByFilters>
  */
 abstract class InputsByFilters extends InputsGeneric implements InputsInterface
 {
@@ -35,6 +35,7 @@ abstract class InputsByFilters extends InputsGeneric implements InputsInterface
 
     public function getFilterOptions(): array
     {
+        /** @var QueryByFilters $query */
         $query = $this->getQuery();
         return [$query->getComplement(), $query->getStateVoucher(), $query->getRfc()];
     }

--- a/src/Inputs/InputsByFiltersIssued.php
+++ b/src/Inputs/InputsByFiltersIssued.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Inputs;
 
+use PhpCfdi\CfdiSatScraper\QueryByFilters;
+
 class InputsByFiltersIssued extends InputsByFilters implements InputsInterface
 {
     /** @return array<string, string> */
     public function getDateFilters(): array
     {
-        $startDate = $this->getQuery()->getStartDate();
-        $endDate = $this->getQuery()->getEndDate();
+        /** @var QueryByFilters $query PhpStorm does not know correct type by template */
+        $query = $this->getQuery();
+        $startDate = $query->getStartDate();
+        $endDate = $query->getEndDate();
         return [
             'ctl00$MainContent$hfInicial' => $startDate->format('Y'),
             'ctl00$MainContent$CldFechaInicial2$Calendario_text' => $startDate->format('d/m/Y'),

--- a/src/Inputs/InputsByFiltersReceived.php
+++ b/src/Inputs/InputsByFiltersReceived.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Inputs;
 
+use PhpCfdi\CfdiSatScraper\QueryByFilters;
+
 class InputsByFiltersReceived extends InputsByFilters implements InputsInterface
 {
     /** @return array<string, string> */
     public function getDateFilters(): array
     {
-        $startDate = $this->getQuery()->getStartDate();
-        $endDate = $this->getQuery()->getEndDate();
+        /** @var QueryByFilters $query PhpStorm does not know correct type by template */
+        $query = $this->getQuery();
+        $startDate = $query->getStartDate();
+        $endDate = $query->getEndDate();
         return [
             'ctl00$MainContent$CldFecha$DdlAnio' => $startDate->format('Y'),
             'ctl00$MainContent$CldFecha$DdlMes' => $this->sidate($startDate, 'm', 1),

--- a/src/Inputs/InputsByUuid.php
+++ b/src/Inputs/InputsByUuid.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\CfdiSatScraper\Inputs;
 use PhpCfdi\CfdiSatScraper\QueryByUuid;
 
 /**
- * @method QueryByUuid getQuery()
+ * @extends InputsGeneric<QueryByUuid>
  */
 class InputsByUuid extends InputsGeneric implements InputsInterface
 {

--- a/src/Inputs/InputsGeneric.php
+++ b/src/Inputs/InputsGeneric.php
@@ -6,16 +6,21 @@ namespace PhpCfdi\CfdiSatScraper\Inputs;
 
 use PhpCfdi\CfdiSatScraper\Contracts\QueryInterface;
 
+/**
+ * @template TQuery of QueryInterface
+ */
 abstract class InputsGeneric implements InputsInterface
 {
-    /** @var QueryInterface */
+    /** @var TQuery */
     private $query;
 
+    /** @param TQuery $query */
     public function __construct(QueryInterface $query)
     {
         $this->query = $query;
     }
 
+    /** @return TQuery */
     public function getQuery(): QueryInterface
     {
         return $this->query;

--- a/src/Inputs/InputsInterface.php
+++ b/src/Inputs/InputsInterface.php
@@ -31,7 +31,7 @@ interface InputsInterface
     public function getCentralFilter(): string;
 
     /**
-     * Return only the appropiate key-values to override based on the query
+     * Return only the appropriate key-values to override based on the query
      *
      * @return array<string, string>
      */
@@ -45,7 +45,7 @@ interface InputsInterface
     public function getAjaxInputs(): array;
 
     /**
-     * Return the URL which all http transactions will be send
+     * Return the URL which all http transactions will be sent
      *
      * @return string
      */

--- a/src/Internal/CaptchaBase64Extractor.php
+++ b/src/Internal/CaptchaBase64Extractor.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Internal;
 
+use PhpCfdi\CfdiSatScraper\Exceptions\RuntimeException;
 use PhpCfdi\ImageCaptchaResolver\CaptchaImage;
-use RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
 
 /** @internal */
@@ -18,7 +18,7 @@ class CaptchaBase64Extractor
         $images = (new Crawler($htmlSource))->filter($selector);
 
         if (0 === $images->count()) {
-            throw new RuntimeException("Unable to find image using filter '$selector'");
+            throw RuntimeException::unableToFindCaptchaImage($selector);
         }
 
         $imageSource = (string) $images->attr('src');

--- a/src/Internal/CaptchaBase64Extractor.php
+++ b/src/Internal/CaptchaBase64Extractor.php
@@ -8,7 +8,11 @@ use PhpCfdi\CfdiSatScraper\Exceptions\RuntimeException;
 use PhpCfdi\ImageCaptchaResolver\CaptchaImage;
 use Symfony\Component\DomCrawler\Crawler;
 
-/** @internal */
+/**
+ * This is a class to extract the captcha from the log in web page.
+ *
+ * @internal
+ */
 class CaptchaBase64Extractor
 {
     public const DEFAULT_SELECTOR = '#divCaptcha > img';

--- a/src/Internal/CaptchaBase64Extractor.php
+++ b/src/Internal/CaptchaBase64Extractor.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\CfdiSatScraper\Captcha;
+namespace PhpCfdi\CfdiSatScraper\Internal;
 
 use PhpCfdi\ImageCaptchaResolver\CaptchaImage;
 use RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
 
+/** @internal */
 class CaptchaBase64Extractor
 {
     public const DEFAULT_SELECTOR = '#divCaptcha > img';

--- a/src/Internal/DownloadTypePropertyTrait.php
+++ b/src/Internal/DownloadTypePropertyTrait.php
@@ -6,6 +6,11 @@ namespace PhpCfdi\CfdiSatScraper\Internal;
 
 use PhpCfdi\CfdiSatScraper\Filters\DownloadType;
 
+/**
+ * This trait contains the methods to insert a $downloadType property
+ *
+ * @internal
+ */
 trait DownloadTypePropertyTrait
 {
     /** @var DownloadType */

--- a/src/Internal/DownloadTypePropertyTrait.php
+++ b/src/Internal/DownloadTypePropertyTrait.php
@@ -25,7 +25,7 @@ trait DownloadTypePropertyTrait
      * @param DownloadType $downloadType
      * @return $this
      */
-    public function setDownloadType(DownloadType $downloadType)
+    public function setDownloadType(DownloadType $downloadType): self
     {
         $this->downloadType = $downloadType;
 

--- a/src/Internal/Headers.php
+++ b/src/Internal/Headers.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Internal;
 
 /**
- * Helper class to return the correct headers for different requests: post and ajax
+ * Helper class to return the correct headers for different requests: post and ajax.
+ *
  * @internal
  */
 class Headers

--- a/src/Internal/HtmlForm.php
+++ b/src/Internal/HtmlForm.php
@@ -85,7 +85,7 @@ class HtmlForm
     {
         $data = [];
         /** @var DOMElement[] $elements */
-        $elements = $this->filterCrawlerElements("{$this->parentElement} select");
+        $elements = $this->filterCrawlerElements("$this->parentElement select");
         foreach ($elements as $element) {
             $name = $element->getAttribute('name');
             if ($this->elementNameIsExcluded($name)) {
@@ -111,7 +111,7 @@ class HtmlForm
      * This method is compatible with elements that have a name and value
      * It excludes the selects which name match with an exclusion pattern
      * If type is defined is excluded if was set as an excluded type
-     * If type is radio is included only if checked attribute is trueish
+     * If type is radio is included only if checked attribute is true-ish
      *
      * @param string $element
      * @param string[] $excludeTypes
@@ -124,7 +124,7 @@ class HtmlForm
         $data = [];
 
         /** @var DOMElement[] $elements */
-        $elements = $this->filterCrawlerElements("{$this->parentElement} {$element}");
+        $elements = $this->filterCrawlerElements("$this->parentElement $element");
         foreach ($elements as $element) {
             $name = $element->getAttribute('name');
             if ($this->elementNameIsExcluded($name)) {

--- a/src/Internal/HtmlForm.php
+++ b/src/Internal/HtmlForm.php
@@ -10,6 +10,7 @@ use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * Utility class to extract data from an HTML form.
+ *
  * @internal
  */
 class HtmlForm

--- a/src/Internal/MetaRefreshInspector.php
+++ b/src/Internal/MetaRefreshInspector.php
@@ -7,6 +7,11 @@ namespace PhpCfdi\CfdiSatScraper\Internal;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\UriResolver;
 
+/**
+ * This is a class to inspect a web page and find if there is a http meta refresh instruction.
+ *
+ * @internal
+ */
 final class MetaRefreshInspector
 {
     public function obtainUrl(string $html, string $baseUri): string

--- a/src/Internal/MetadataDownloader.php
+++ b/src/Internal/MetadataDownloader.php
@@ -26,6 +26,7 @@ use PhpCfdi\CfdiSatScraper\QueryByUuid;
  * Has a copy of callable to raise when limit is reached
  *
  * @see QueryResolver
+ * @internal
  */
 class MetadataDownloader
 {

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -36,7 +36,7 @@ class MetadataExtractor
             return new MetadataList([]);
         }
 
-        // first tr is the only expected to have the th elements
+        // first row is the only expected to have the th elements
         $fieldsPositions = $this->locateFieldsPositions($rows->first(), $fieldsCaptions);
 
         // slice first row (headers), build data array as a collection of metadata

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -12,6 +12,8 @@ use RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
+ * Parses a web page to obtain all the Metadata records on it.
+ *
  * @internal
  */
 class MetadataExtractor

--- a/src/Internal/NullMaximumRecordsHandler.php
+++ b/src/Internal/NullMaximumRecordsHandler.php
@@ -7,6 +7,11 @@ namespace PhpCfdi\CfdiSatScraper\Internal;
 use DateTimeImmutable;
 use PhpCfdi\CfdiSatScraper\Contracts\MaximumRecordsHandler;
 
+/**
+ * Null implementation of MaximumRecordsHandler.
+ *
+ * @internal
+ */
 final class NullMaximumRecordsHandler implements MaximumRecordsHandler
 {
     public function handle(DateTimeImmutable $moment): void

--- a/src/Internal/QueryResolver.php
+++ b/src/Internal/QueryResolver.php
@@ -48,8 +48,7 @@ class QueryResolver
         $htmlWithMetadata = $this->htmlFromExecuteQuery($url, $post);
 
         // extract metadata from search results
-        $metadataList = (new MetadataExtractor())->extract($htmlWithMetadata);
-        return $metadataList;
+        return (new MetadataExtractor())->extract($htmlWithMetadata);
     }
 
     /**
@@ -62,8 +61,7 @@ class QueryResolver
         $completePage = $this->getSatHttpGateway()->getPortalPage($url);
         $completePage = str_replace('charset=utf-16', 'charset=utf-8', $completePage); // quick and dirty hack
         $htmlFormInputExtractor = new HtmlForm($completePage, 'form', ['/^ctl00\$MainContent\$Btn.+/', '/^seleccionador$/']);
-        $baseInputs = $htmlFormInputExtractor->getFormValues();
-        return $baseInputs;
+        return $htmlFormInputExtractor->getFormValues();
     }
 
     /**
@@ -75,8 +73,7 @@ class QueryResolver
     protected function inputFieldsFromSelectDownloadType(string $url, array $post): array
     {
         $html = $this->getSatHttpGateway()->postAjaxSearch($url, $post); // this html is used to update __VARIABLES
-        $lastViewStateValues = (new ParserFormatSAT())->getFormValues($html);
-        return $lastViewStateValues;
+        return (new ParserFormatSAT())->getFormValues($html);
     }
 
     /**
@@ -87,9 +84,7 @@ class QueryResolver
      */
     protected function htmlFromExecuteQuery(string $url, array $post): string
     {
-        // consume search using search filters
-        $htmlWithMetadataContent = $this->getSatHttpGateway()->postAjaxSearch($url, $post);
-        return $htmlWithMetadataContent;
+        return $this->getSatHttpGateway()->postAjaxSearch($url, $post);
     }
 
     public function getSatHttpGateway(): SatHttpGateway

--- a/src/Internal/ResourceDownloadStoreInFolder.php
+++ b/src/Internal/ResourceDownloadStoreInFolder.php
@@ -16,6 +16,7 @@ use Throwable;
  * This is a class to perform the ResourceDownloader::saveTo method.
  *
  * @see \PhpCfdi\CfdiSatScraper\ResourceDownloader::saveTo()
+ * @internal
  */
 final class ResourceDownloadStoreInFolder implements ResourceDownloadHandlerInterface
 {

--- a/src/Internal/ResourceDownloaderPromiseHandler.php
+++ b/src/Internal/ResourceDownloaderPromiseHandler.php
@@ -41,7 +41,7 @@ final class ResourceDownloaderPromiseHandler implements ResourceDownloaderPromis
     }
 
     /**
-     * This method handles the each promise fulfilled event
+     * This method handles each promise fulfilled event
      *
      * @param ResponseInterface $response
      * @param string $uuid
@@ -99,7 +99,7 @@ final class ResourceDownloaderPromiseHandler implements ResourceDownloaderPromis
     }
 
     /**
-     * This method handles the each promise rejected event
+     * This method handles each promise rejected event
      *
      * @param mixed $reason
      * @param string $uuid
@@ -127,7 +127,7 @@ final class ResourceDownloaderPromiseHandler implements ResourceDownloaderPromis
     }
 
     /**
-     * Return the list of succesfully processed UUIDS
+     * Return the list of successfully processed UUIDS
      *
      * @return string[]
      */

--- a/src/Internal/ResourceFileNamerByType.php
+++ b/src/Internal/ResourceFileNamerByType.php
@@ -9,7 +9,7 @@ use PhpCfdi\CfdiSatScraper\Contracts\ResourceFileNamerInterface;
 use PhpCfdi\CfdiSatScraper\ResourceType;
 
 /**
- * This class is an implementation of ResourceFileNamerInterface to create a file name for an UUID
+ * This class is an implementation of ResourceFileNamerInterface to create a file name for a UUID
  * depending on a resource type.
  *
  * @internal

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -8,10 +8,10 @@ use JsonSerializable;
 use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
 
 /**
- * The Metadata class is an storage of values retrieved from the list of documents obtained from
- * a seach on the SAT CFDI Portal.
+ * The Metadata class is a storage of values retrieved from the list of documents obtained from
+ * a search on the SAT CFDI Portal.
  *
- * It always has an UUID, all other properties are optional.
+ * It always has a UUID, all other properties are optional.
  */
 class Metadata implements JsonSerializable
 {

--- a/src/MetadataList.php
+++ b/src/MetadataList.php
@@ -9,14 +9,13 @@ use Countable;
 use IteratorAggregate;
 use JsonSerializable;
 use PhpCfdi\CfdiSatScraper\Exceptions\LogicException;
-use Traversable;
 
 /**
- * @implements \IteratorAggregate<Metadata>
+ * @implements IteratorAggregate<Metadata>
  */
 class MetadataList implements Countable, IteratorAggregate, JsonSerializable
 {
-    /** @var Metadata[] */
+    /** @var array<string, Metadata> */
     private $list;
 
     /** @param Metadata[] $list */
@@ -63,7 +62,7 @@ class MetadataList implements Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
-     * Return a new list with only the Metadata wich has an url to download according to specified resource type
+     * Return a new list with only the Metadata which has an url to download according to specified resource type
      *
      * @param ResourceType $resourceType
      * @return self
@@ -92,7 +91,7 @@ class MetadataList implements Countable, IteratorAggregate, JsonSerializable
     }
 
     /**
-     * Obtain a Metadata by UUID, the metadata object must exists in the collection
+     * Obtain a Metadata by UUID, the metadata object must exist in the collection
      *
      * @param string $uuid
      * @return Metadata
@@ -107,10 +106,8 @@ class MetadataList implements Countable, IteratorAggregate, JsonSerializable
         return $values;
     }
 
-    /**
-     * @return Traversable<Metadata>
-     */
-    public function getIterator()
+    /** @return ArrayIterator<string, Metadata> */
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->list);
     }

--- a/src/SatHttpGateway.php
+++ b/src/SatHttpGateway.php
@@ -215,13 +215,27 @@ class SatHttpGateway
             } else {
                 $this->effectiveUri = $uri;
             }
-            throw SatHttpGatewayClientException::clientException($reason, 'GET', $uri, $options[RequestOptions::HEADERS], [], $exception);
+            throw SatHttpGatewayClientException::clientException(
+                $reason,
+                $method,
+                $uri,
+                $options[RequestOptions::HEADERS],
+                $options[RequestOptions::FORM_PARAMS] ?? [],
+                $exception,
+            );
         }
         $this->setEffectiveUriFromResponse($response, $uri);
 
         $contents = strval($response->getBody());
         if ('' === $contents) {
-            throw SatHttpGatewayResponseException::unexpectedEmptyResponse($reason, $response, 'GET', $uri, $options[RequestOptions::HEADERS]);
+            throw SatHttpGatewayResponseException::unexpectedEmptyResponse(
+                $reason,
+                $response,
+                $method,
+                $uri,
+                $options[RequestOptions::HEADERS],
+                $options[RequestOptions::FORM_PARAMS] ?? [],
+            );
         }
 
         return $contents;

--- a/src/SatHttpGateway.php
+++ b/src/SatHttpGateway.php
@@ -129,7 +129,7 @@ class SatHttpGateway
     }
 
     /**
-     * Create a promise (asyncronic request) to perform an XML download.
+     * Create a promise (asynchronous request) to perform an XML download.
      *
      * @param string $link
      * @return PromiseInterface

--- a/src/SatScraper.php
+++ b/src/SatScraper.php
@@ -5,15 +5,14 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper;
 
 use PhpCfdi\CfdiSatScraper\Contracts\MaximumRecordsHandler;
-use PhpCfdi\CfdiSatScraper\Exceptions\LoginException;
-use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayException;
+use PhpCfdi\CfdiSatScraper\Contracts\SatScraperInterface;
 use PhpCfdi\CfdiSatScraper\Filters\DownloadType;
 use PhpCfdi\CfdiSatScraper\Internal\MetadataDownloader;
 use PhpCfdi\CfdiSatScraper\Internal\NullMaximumRecordsHandler;
 use PhpCfdi\CfdiSatScraper\Internal\QueryResolver;
 use PhpCfdi\CfdiSatScraper\Sessions\SessionManager;
 
-class SatScraper
+class SatScraper implements SatScraperInterface
 {
     /** @var SessionManager */
     private $sessionManager;
@@ -71,15 +70,6 @@ class SatScraper
         return new QueryResolver($this->satHttpGateway);
     }
 
-    /**
-     * Create a ResourceDownloader object with (optionally) a MetadataList.
-     * Use the ResourceDownloader to retrieve the CFDI related files.
-     *
-     * @param ResourceType|null $resourceType
-     * @param MetadataList|null $metadataList
-     * @param int $concurrency
-     * @return ResourceDownloader
-     */
     public function resourceDownloader(
         ResourceType $resourceType = null,
         ?MetadataList $metadataList = null,
@@ -89,12 +79,6 @@ class SatScraper
         return new ResourceDownloader($this->satHttpGateway, $resourceType, $metadataList, $concurrency);
     }
 
-    /**
-     * Initializes session on SAT
-     *
-     * @return SatScraper
-     * @throws LoginException if session is not alive
-     */
     public function confirmSessionIsAlive(): self
     {
         $sessionManager = $this->getSessionManager();
@@ -108,43 +92,18 @@ class SatScraper
         return $this;
     }
 
-    /**
-     * Retrieve the MetadataList using specific UUIDS to download
-     *
-     * @param string[] $uuids
-     * @param DownloadType $downloadType
-     * @return MetadataList
-     * @throws LoginException
-     * @throws SatHttpGatewayException
-     */
     public function listByUuids(array $uuids, DownloadType $downloadType): MetadataList
     {
         $this->confirmSessionIsAlive();
         return $this->createMetadataDownloader()->downloadByUuids($uuids, $downloadType);
     }
 
-    /**
-     * Retrieve the MetadataList based on the query, but uses full days on dates (without time parts)
-     *
-     * @param QueryByFilters $query
-     * @return MetadataList
-     * @throws LoginException
-     * @throws SatHttpGatewayException
-     */
     public function listByPeriod(QueryByFilters $query): MetadataList
     {
         $this->confirmSessionIsAlive();
         return $this->createMetadataDownloader()->downloadByDate($query);
     }
 
-    /**
-     * Retrieve the MetadataList based on the query, but uses the period considering dates and times
-     *
-     * @param QueryByFilters $query
-     * @return MetadataList
-     * @throws LoginException
-     * @throws SatHttpGatewayException
-     */
     public function listByDateTime(QueryByFilters $query): MetadataList
     {
         $this->confirmSessionIsAlive();

--- a/src/Sessions/AbstractSessionManager.php
+++ b/src/Sessions/AbstractSessionManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Sessions;
 
-use LogicException;
+use PhpCfdi\CfdiSatScraper\Exceptions\LogicException;
 use PhpCfdi\CfdiSatScraper\Exceptions\LoginException;
 use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayException;
 use PhpCfdi\CfdiSatScraper\Internal\HtmlForm;
@@ -45,7 +45,7 @@ abstract class AbstractSessionManager implements SessionManager
     public function getHttpGateway(): SatHttpGateway
     {
         if (null === $this->httpGateway) {
-            throw new LogicException('Must set http gateway property before use');
+            throw LogicException::generic('Must set http gateway property before use');
         }
         return $this->httpGateway;
     }

--- a/src/Sessions/Ciec/CiecLoginException.php
+++ b/src/Sessions/Ciec/CiecLoginException.php
@@ -26,14 +26,14 @@ class CiecLoginException extends LoginException
      * @param string $message
      * @param CiecSessionData $sessionData
      * @param string $contents
-     * @param array<string, mixed> $post
+     * @param array<string, mixed> $postedData
      * @param Throwable|null $previous
      */
-    public function __construct(string $message, CiecSessionData $sessionData, string $contents, array $post = [], Throwable $previous = null)
+    public function __construct(string $message, CiecSessionData $sessionData, string $contents, array $postedData = [], Throwable $previous = null)
     {
         parent::__construct($message, $contents, $previous);
         $this->sessionData = $sessionData;
-        $this->postedData = $post;
+        $this->postedData = $postedData;
     }
 
     public static function notRegisteredAfterLogin(CiecSessionData $data, string $contents): self

--- a/src/Sessions/Ciec/CiecLoginException.php
+++ b/src/Sessions/Ciec/CiecLoginException.php
@@ -42,9 +42,9 @@ class CiecLoginException extends LoginException
         return new self($message, $data, $contents);
     }
 
-    public static function noCaptchaImageFound(CiecSessionData $data, string $contents): self
+    public static function noCaptchaImageFound(CiecSessionData $data, string $contents, Throwable $previous = null): self
     {
-        return new self('It was unable to find the captcha image', $data, $contents);
+        return new self('It was unable to find the captcha image', $data, $contents, [], $previous);
     }
 
     public static function captchaWithoutAnswer(CiecSessionData $data, CaptchaImage $captchaImage, Throwable $previous = null): self

--- a/src/Sessions/Ciec/CiecSessionData.php
+++ b/src/Sessions/Ciec/CiecSessionData.php
@@ -8,7 +8,7 @@ use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
 use PhpCfdi\ImageCaptchaResolver\CaptchaResolverInterface;
 
 /**
- * This immutable class is the store of the data required to login into SAT
+ * This immutable class is the store of the data required to log in into SAT
  */
 class CiecSessionData
 {

--- a/src/Sessions/Ciec/CiecSessionManager.php
+++ b/src/Sessions/Ciec/CiecSessionManager.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Sessions\Ciec;
 
-use PhpCfdi\CfdiSatScraper\Captcha\CaptchaBase64Extractor;
 use PhpCfdi\CfdiSatScraper\Exceptions\LoginException;
 use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayException;
+use PhpCfdi\CfdiSatScraper\Internal\CaptchaBase64Extractor;
 use PhpCfdi\CfdiSatScraper\Sessions\AbstractSessionManager;
 use PhpCfdi\CfdiSatScraper\Sessions\SessionManager;
 use PhpCfdi\CfdiSatScraper\URLS;

--- a/src/Sessions/Ciec/CiecSessionManager.php
+++ b/src/Sessions/Ciec/CiecSessionManager.php
@@ -40,12 +40,15 @@ final class CiecSessionManager extends AbstractSessionManager implements Session
         } catch (SatHttpGatewayException $exception) {
             throw CiecLoginException::connectionException('getting captcha image', $this->sessionData, $exception);
         }
-        $captchaBase64Extractor = new CaptchaBase64Extractor();
-        $imageBase64 = $captchaBase64Extractor->retrieve($html);
-        if ('' === $imageBase64) {
-            throw CiecLoginException::noCaptchaImageFound($this->sessionData, $html);
+
+        try {
+            $captchaBase64Extractor = new CaptchaBase64Extractor();
+            $captchaImage = $captchaBase64Extractor->retrieveCaptchaImage($html);
+        } catch (Throwable $exception) {
+            throw CiecLoginException::noCaptchaImageFound($this->sessionData, $html, $exception);
         }
-        return CaptchaImage::newFromBase64($imageBase64);
+
+        return $captchaImage;
     }
 
     /**

--- a/src/Sessions/SessionManager.php
+++ b/src/Sessions/SessionManager.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Sessions;
 
-use LogicException;
+use PhpCfdi\CfdiSatScraper\Exceptions\LogicException;
 use PhpCfdi\CfdiSatScraper\Exceptions\LoginException;
 use PhpCfdi\CfdiSatScraper\SatHttpGateway;
 

--- a/tests/Integration/Factory.php
+++ b/tests/Integration/Factory.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @noinspection PhpUnhandledExceptionInspection
- */
-
 declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
@@ -111,7 +107,6 @@ class Factory
         return new CiecSessionManager($this->createCiecSessionData());
     }
 
-    /** @noinspection PhpUnhandledExceptionInspection */
     public function createCiecSessionData(): CiecSessionData
     {
         $rfc = $this->env('SAT_AUTH_RFC');

--- a/tests/Integration/HttpLogger.php
+++ b/tests/Integration/HttpLogger.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @noinspection PhpUnhandledExceptionInspection
- */
-
 declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Integration;

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -50,7 +50,7 @@ class IntegrationTestCase extends TestCase
         }
     }
 
-    /** @return mixed[] */
+    /** @return array<string, array{DownloadType}> */
     public function providerEmitidosRecibidos(): array
     {
         return [

--- a/tests/Integration/LoginUsingCiecTest.php
+++ b/tests/Integration/LoginUsingCiecTest.php
@@ -8,7 +8,6 @@ use Throwable;
 
 final class LoginUsingCiecTest extends IntegrationTestCase
 {
-    /** @noinspection PhpUnhandledExceptionInspection */
     public function testLoginAndLogout(): void
     {
         $factory = $this->getFactory();

--- a/tests/Integration/LoginUsingFielTest.php
+++ b/tests/Integration/LoginUsingFielTest.php
@@ -8,7 +8,6 @@ use Throwable;
 
 final class LoginUsingFielTest extends IntegrationTestCase
 {
-    /** @noinspection PhpUnhandledExceptionInspection */
     public function testLoginAndLogout(): void
     {
         $factory = $this->getFactory();

--- a/tests/Integration/Repository.php
+++ b/tests/Integration/Repository.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @noinspection PhpUnhandledExceptionInspection
- */
-
 declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Integration;

--- a/tests/Integration/RepositoryItem.php
+++ b/tests/Integration/RepositoryItem.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
 
 use DateTimeImmutable;
+use DomainException;
+use Exception;
 use JsonSerializable;
 
 class RepositoryItem implements JsonSerializable
@@ -29,20 +31,24 @@ class RepositoryItem implements JsonSerializable
         $this->state = strtoupper(substr($state, 0, 1));
     }
 
-    /**
-     * @param array<string, string> $item
-     * @return self
-     */
+    /** @param array<string, string> $item */
     public static function fromArray(array $item): self
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
-        $dateTime = new DateTimeImmutable(strval($item['date'] ?? ''));
         return new self(
             strval($item['uuid'] ?? ''),
-            $dateTime,
+            static::dateFromString(strval($item['date'] ?? '')),
             strval($item['state'] ?? ''),
             strval($item['type'] ?? ''),
         );
+    }
+
+    private static function dateFromString(string $value): DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $exception) {
+            throw new DomainException(sprintf('Unable to parse date with value %s', $value));
+        }
     }
 
     public function getUuid(): string

--- a/tests/Integration/RetrieveByUuidTest.php
+++ b/tests/Integration/RetrieveByUuidTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\CfdiSatScraper\ResourceType;
 
 class RetrieveByUuidTest extends IntegrationTestCase
 {
-    /** @return mixed[] */
+    /** @return array<string, array{DownloadType, int}> */
     public function providerRetrieveByUuid(): array
     {
         return [

--- a/tests/Unit/Captcha/CaptchaBase64ExtractorTest.php
+++ b/tests/Unit/Captcha/CaptchaBase64ExtractorTest.php
@@ -20,7 +20,7 @@ final class CaptchaBase64ExtractorTest extends TestCase
         $base64Image = $this->getBase64Image();
         $html = <<< HTML
             <div id="divCaptcha">
-                <img src="data:image/jpeg;base64,{$base64Image}">
+                <img src="data:image/jpeg;base64,$base64Image">
             </div>
             HTML;
 
@@ -33,7 +33,7 @@ final class CaptchaBase64ExtractorTest extends TestCase
         $base64Image = $this->getBase64Image();
         $html = <<< HTML
             <div>
-                <img src="data:image/jpeg;base64,{$base64Image}">
+                <img src="data:image/jpeg;base64,$base64Image">
             </div>
             HTML;
 
@@ -49,7 +49,7 @@ final class CaptchaBase64ExtractorTest extends TestCase
         $base64Image = $this->getBase64Image();
         $html = <<< HTML
             <div id="captcha">
-                <img src="data:image/jpeg;base64,{$base64Image}">
+                <img src="data:image/jpeg;base64,$base64Image">
             </div>
             HTML;
 

--- a/tests/Unit/Exceptions/InvalidArgumentExceptionTest.php
+++ b/tests/Unit/Exceptions/InvalidArgumentExceptionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use DateTimeImmutable;
+use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+
+final class InvalidArgumentExceptionTest extends TestCase
+{
+    public function testHierarchy(): void
+    {
+        $exception = $this->createMock(InvalidArgumentException::class);
+        $this->assertInstanceOf(\InvalidArgumentException::class, $exception);
+        $this->assertInstanceOf(SatException::class, $exception);
+    }
+
+    public function testEmptyInput(): void
+    {
+        $exception = InvalidArgumentException::emptyInput('x-input');
+        $this->assertSame(
+            'Invalid argument x-input is empty',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testPeriodStartDateGreaterThanEndDate(): void
+    {
+        $since = new DateTimeImmutable('2021-12-31');
+        $until = new DateTimeImmutable('2021-01-01');
+        $exception = InvalidArgumentException::periodStartDateGreaterThanEndDate($since, $until);
+        $this->assertSame(
+            'The start date 2021-12-31 00:00:00 is greater than the end date 2021-01-01 00:00:00',
+            $exception->getMessage(),
+        );
+    }
+
+    public function testComplementsOptionInvalidKey(): void
+    {
+        $exception = InvalidArgumentException::complementsOptionInvalidKey('x-key');
+        $this->assertSame(
+            "The key 'x-key' is not registered as a valid option for ComplementsOption",
+            $exception->getMessage(),
+        );
+    }
+}

--- a/tests/Unit/Exceptions/LogicExceptionTest.php
+++ b/tests/Unit/Exceptions/LogicExceptionTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\CfdiSatScraper\Exceptions\LogicException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+
+final class LogicExceptionTest extends TestCase
+{
+    public function testHierarchy(): void
+    {
+        $exception = $this->createMock(LogicException::class);
+        $this->assertInstanceOf(\LogicException::class, $exception);
+        $this->assertInstanceOf(SatException::class, $exception);
+    }
+
+    public function testGeneric(): void
+    {
+        $previous = $this->createMock(\LogicException::class);
+        $exception = LogicException::generic('testing exception', $previous);
+        $this->assertSame('testing exception', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Unit/Exceptions/LoginExceptionTest.php
+++ b/tests/Unit/Exceptions/LoginExceptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\CfdiSatScraper\Exceptions\LoginException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+use Throwable;
+
+final class LoginExceptionTest extends TestCase
+{
+    public function testHierarchy(): void
+    {
+        $exception = $this->createMock(LoginException::class);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
+        $this->assertInstanceOf(SatException::class, $exception);
+    }
+
+    public function testProperties(): void
+    {
+        $message = 'x-message';
+        $contents = 'x-contents';
+        $previous = $this->createMock(Throwable::class);
+
+        $exception = new class ($message, $contents, $previous) extends LoginException {
+        };
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+        $this->assertSame($contents, $exception->getContents());
+    }
+}

--- a/tests/Unit/Exceptions/ResourceDownloadErrorTest.php
+++ b/tests/Unit/Exceptions/ResourceDownloadErrorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\CfdiSatScraper\Exceptions\ResourceDownloadError;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+use RuntimeException;
+use Throwable;
+
+final class ResourceDownloadErrorTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $message = 'message';
+        $uuid = 'uuid';
+        $reason = 'reason';
+        $previous = $this->createMock(Throwable::class);
+
+        $exception = new ResourceDownloadError($message, $uuid, $reason, $previous);
+
+        $this->assertInstanceOf(RuntimeException::class, $exception);
+        $this->assertInstanceOf(SatException::class, $exception);
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($reason, $exception->getReason());
+    }
+
+    public function testConstructorWithThrowableReasonWithoutPrevious(): void
+    {
+        $message = 'message';
+        $uuid = 'uuid';
+        $reason = $this->createMock(Throwable::class);
+
+        $exception = new ResourceDownloadError($message, $uuid, $reason);
+
+        $this->assertSame($reason, $exception->getPrevious());
+        $this->assertSame($reason, $exception->getReason());
+    }
+
+    public function testOnRejected(): void
+    {
+        $uuid = 'uuid';
+        $reason = 'something';
+        $exception = ResourceDownloadError::onRejected($uuid, $reason);
+        $this->assertSame("Download of UUID uuid was rejected, reason: $reason", $exception->getMessage());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($reason, $exception->getReason());
+    }
+
+    /** @return array<string, array{string, mixed}> */
+    public function providerReasonToString(): array
+    {
+        $stringable = new class () {
+            public function __toString(): string
+            {
+                return 'fixed response';
+            }
+        };
+        $other = (object) ['foo' => 'bar'];
+        return [
+            'string' => ['string', 'string'],
+            'scalar' => ['123', 123],
+            'throwable' => ['RuntimeException: Message', new RuntimeException('Message')],
+            'stringable' => ['fixed response', $stringable],
+            'other' => [print_r($other, true), $other],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param mixed $reason
+     * @dataProvider providerReasonToString
+     */
+    public function testReasonToString(string $expected, $reason): void
+    {
+        $value = ResourceDownloadError::reasonToString($reason);
+        $this->assertSame($expected, $value);
+    }
+}

--- a/tests/Unit/Exceptions/ResourceDownloadRequestExceptionErrorTest.php
+++ b/tests/Unit/Exceptions/ResourceDownloadRequestExceptionErrorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use GuzzleHttp\Exception\RequestException;
+use PhpCfdi\CfdiSatScraper\Exceptions\ResourceDownloadError;
+use PhpCfdi\CfdiSatScraper\Exceptions\ResourceDownloadRequestExceptionError;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+
+final class ResourceDownloadRequestExceptionErrorTest extends TestCase
+{
+    public function testHierarchy(): void
+    {
+        $exception = $this->createMock(ResourceDownloadRequestExceptionError::class);
+        $this->assertInstanceOf(ResourceDownloadError::class, $exception);
+    }
+
+    public function testOnRequestException(): void
+    {
+        $requestException = $this->createMock(RequestException::class);
+        $uuid = 'uuid';
+        $exception = ResourceDownloadRequestExceptionError::onRequestException($requestException, $uuid);
+        $this->assertSame('Download of CFDI uuid fails when performing request', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($requestException, $exception->getPrevious());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($requestException, $exception->getReason());
+    }
+}

--- a/tests/Unit/Exceptions/ResourceDownloadResponseErrorTest.php
+++ b/tests/Unit/Exceptions/ResourceDownloadResponseErrorTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\CfdiSatScraper\Exceptions\ResourceDownloadError;
+use PhpCfdi\CfdiSatScraper\Exceptions\ResourceDownloadResponseError;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
+
+final class ResourceDownloadResponseErrorTest extends TestCase
+{
+    public function testHierarchy(): void
+    {
+        $exception = $this->createMock(ResourceDownloadResponseError::class);
+        $this->assertInstanceOf(ResourceDownloadError::class, $exception);
+    }
+
+    public function testInvalidStatusCode(): void
+    {
+        /** @var ResponseInterface&MockObject $response */
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getStatusCode')->willReturn('503');
+        $uuid = 'uuid';
+        $exception = ResourceDownloadResponseError::invalidStatusCode($response, $uuid);
+        $this->assertSame(
+            'Download of CFDI uuid return an invalid status code 503',
+            $exception->getMessage(),
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($response, $exception->getReason());
+    }
+
+    public function testEmptyContent(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $uuid = 'uuid';
+        $exception = ResourceDownloadResponseError::emptyContent($response, $uuid);
+        $this->assertSame('Download of CFDI uuid return an empty body', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($response, $exception->getReason());
+    }
+
+    public function testContentIsNotCfdi(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $uuid = 'uuid';
+        $exception = ResourceDownloadResponseError::contentIsNotCfdi($response, $uuid);
+        $this->assertSame('Download of CFDI uuid return something that is not a CFDI', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($response, $exception->getReason());
+    }
+
+    public function testContentIsNotPdf(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $uuid = 'uuid';
+        $exception = ResourceDownloadResponseError::contentIsNotPdf($response, $uuid, 'text/plain');
+        $this->assertSame(
+            'Download of CFDI uuid return something that is not a PDF (mime text/plain)',
+            $exception->getMessage(),
+        );
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($response, $exception->getReason());
+    }
+
+    public function testOnSuccessException(): void
+    {
+        $previous = $this->createMock(Throwable::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $uuid = 'uuid';
+        $exception = ResourceDownloadResponseError::onSuccessException($response, $uuid, $previous);
+        $this->assertSame('Download of CFDI uuid was unable to handle fulfill', $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+        $this->assertSame($uuid, $exception->getUuid());
+        $this->assertSame($response, $exception->getReason());
+    }
+
+    public function testOnSuccessExceptionWhenExceptionIsAResourceDownloadResponseError(): void
+    {
+        $previous = $this->createMock(ResourceDownloadResponseError::class);
+        $response = $this->createMock(ResponseInterface::class);
+        $uuid = 'uuid';
+        $exception = ResourceDownloadResponseError::onSuccessException($response, $uuid, $previous);
+        $this->assertSame($previous, $exception);
+    }
+}

--- a/tests/Unit/Exceptions/RuntimeExceptionTest.php
+++ b/tests/Unit/Exceptions/RuntimeExceptionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\CfdiSatScraper\Exceptions\RuntimeException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+use Throwable;
+
+final class RuntimeExceptionTest extends TestCase
+{
+    public function testHierarchy(): void
+    {
+        $exception = $this->createMock(RuntimeException::class);
+        $this->assertInstanceOf(\RuntimeException::class, $exception);
+        $this->assertInstanceOf(SatException::class, $exception);
+    }
+
+    public function testPathDoesNotExists(): void
+    {
+        $exception = RuntimeException::pathDoesNotExists('/path/to/file');
+        $this->assertSame('The path /path/to/file does not exists', $exception->getMessage());
+    }
+
+    public function testPathIsNotFolder(): void
+    {
+        $exception = RuntimeException::pathIsNotFolder('/path/to/file');
+        $this->assertSame('The path /path/to/file is not a folder', $exception->getMessage());
+    }
+
+    public function testUnableToCreateFolder(): void
+    {
+        $previous = $this->createMock(Throwable::class);
+        $exception = RuntimeException::unableToCreateFolder('/path/to/file', $previous);
+        $this->assertSame('Unable to create folder /path/to/file', $exception->getMessage());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testUnableToFilePutContents(): void
+    {
+        $previous = $this->createMock(Throwable::class);
+        $exception = RuntimeException::unableToFilePutContents('/path/to/file', $previous);
+        $this->assertSame('Unable to put contents on /path/to/file', $exception->getMessage());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testUnableToFindCaptchaImage(): void
+    {
+        $exception = RuntimeException::unableToFindCaptchaImage('#captcha');
+        $this->assertSame("Unable to find image using filter '#captcha'", $exception->getMessage());
+    }
+}

--- a/tests/Unit/Exceptions/SatHttpGatewayClientExceptionTest.php
+++ b/tests/Unit/Exceptions/SatHttpGatewayClientExceptionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use GuzzleHttp\Exception\GuzzleException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayClientException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayException;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+
+final class SatHttpGatewayClientExceptionTest extends TestCase
+{
+    public function testClientException(): void
+    {
+        $when = 'testing';
+        $method = 'post';
+        $url = 'https://example.com/';
+        $requestHeaders = ['referer' => 'https://external.com/'];
+        $requestData = ['foo' => 'bar'];
+        $guzzleException = $this->createMock(GuzzleException::class);
+
+        $exception = SatHttpGatewayClientException::clientException(
+            $when,
+            $method,
+            $url,
+            $requestHeaders,
+            $requestData,
+            $guzzleException,
+        );
+
+        $this->assertInstanceOf(SatException::class, $exception);
+        $this->assertInstanceOf(SatHttpGatewayException::class, $exception);
+        $this->assertSame("HTTP client error when $when", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertSame($guzzleException, $exception->getPrevious());
+        $this->assertSame($method, $exception->getHttpMethod());
+        $this->assertSame($url, $exception->getUrl());
+        $this->assertSame($requestHeaders, $exception->getRequestHeaders());
+        $this->assertSame($requestData, $exception->getRequestData());
+        $this->assertSame($guzzleException, $exception->getClientException());
+    }
+}

--- a/tests/Unit/Exceptions/SatHttpGatewayResponseExceptionTest.php
+++ b/tests/Unit/Exceptions/SatHttpGatewayResponseExceptionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Exceptions;
+
+use PhpCfdi\CfdiSatScraper\Exceptions\SatException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayException;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayResponseException;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+use Psr\Http\Message\ResponseInterface;
+
+final class SatHttpGatewayResponseExceptionTest extends TestCase
+{
+    public function testUnexpectedEmptyResponse(): void
+    {
+        $when = 'testing';
+        $response = $this->createMock(ResponseInterface::class);
+        $method = 'post';
+        $url = 'https://example.com/';
+        $requestHeaders = ['referer' => 'https://external.com/'];
+        $requestData = ['foo' => 'bar'];
+
+        $exception = SatHttpGatewayResponseException::unexpectedEmptyResponse(
+            $when,
+            $response,
+            $method,
+            $url,
+            $requestHeaders,
+            $requestData,
+        );
+
+        $this->assertInstanceOf(SatException::class, $exception);
+        $this->assertInstanceOf(SatHttpGatewayException::class, $exception);
+        $this->assertSame("Unexpected empty content when $when", $exception->getMessage());
+        $this->assertSame(0, $exception->getCode());
+        $this->assertNull($exception->getPrevious());
+        $this->assertSame($response, $exception->getResponse());
+        $this->assertSame($method, $exception->getHttpMethod());
+        $this->assertSame($url, $exception->getUrl());
+        $this->assertSame($requestHeaders, $exception->getRequestHeaders());
+        $this->assertSame($requestData, $exception->getRequestData());
+    }
+}

--- a/tests/Unit/Internal/CaptchaBase64ExtractorTest.php
+++ b/tests/Unit/Internal/CaptchaBase64ExtractorTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Internal;
 
+use PhpCfdi\CfdiSatScraper\Exceptions\RuntimeException;
 use PhpCfdi\CfdiSatScraper\Internal\CaptchaBase64Extractor;
 use PhpCfdi\CfdiSatScraper\Tests\TestCase;
-use RuntimeException;
 
 final class CaptchaBase64ExtractorTest extends TestCase
 {

--- a/tests/Unit/Internal/CaptchaBase64ExtractorTest.php
+++ b/tests/Unit/Internal/CaptchaBase64ExtractorTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Captcha;
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Internal;
 
-use PhpCfdi\CfdiSatScraper\Captcha\CaptchaBase64Extractor;
+use PhpCfdi\CfdiSatScraper\Internal\CaptchaBase64Extractor;
 use PhpCfdi\CfdiSatScraper\Tests\TestCase;
 use RuntimeException;
 

--- a/tests/Unit/Internal/MetadataDownloaderTest.php
+++ b/tests/Unit/Internal/MetadataDownloaderTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @noinspection PhpUnhandledExceptionInspection
- */
-
 declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Internal;

--- a/tests/Unit/Internal/MetadataExtractorTest.php
+++ b/tests/Unit/Internal/MetadataExtractorTest.php
@@ -19,7 +19,6 @@ final class MetadataExtractorTest extends TestCase
             'rfcEmisor' => 'RFC Emisor',
         ];
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         $firstRow = (new Crawler(
             '<tr><th>Alpha</th><th>Folio Fiscal</th><th>RFC Emisor</th></tr>',
         ))->filter('tr')->first();
@@ -41,7 +40,6 @@ final class MetadataExtractorTest extends TestCase
             'bar' => 1, // bravo
         ];
 
-        /** @noinspection PhpUnhandledExceptionInspection */
         $row = (new Crawler(
             '<tr><td>Alpha</td><td>Bravo</td><td>Charlie</td><td>Delta</td><td>Echo</td></tr>',
         ))->filter('tr')->first();
@@ -58,7 +56,6 @@ final class MetadataExtractorTest extends TestCase
 
     public function testObtainMetadataValuesWithEmptyRow(): void
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $row = (new Crawler('<tr></tr>'))->filter('tr')->first();
         $extractor = new MetadataExtractor();
         $values = $extractor->obtainMetadataValues($row, ['uuid' => 1]);
@@ -68,7 +65,6 @@ final class MetadataExtractorTest extends TestCase
 
     public function testObtainUrlWithoutButton(): void
     {
-        /** @noinspection PhpUnhandledExceptionInspection */
         $row = (new Crawler('<tr></tr>'))->filter('tr')->first();
         $extractor = new MetadataExtractor();
         $this->assertEmpty($extractor->obtainUrlXml($row));

--- a/tests/Unit/Internal/QueryResolverTest.php
+++ b/tests/Unit/Internal/QueryResolverTest.php
@@ -1,9 +1,5 @@
 <?php
 
-/**
- * @noinspection PhpUnhandledExceptionInspection
- */
-
 declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Internal;

--- a/tests/Unit/Internal/ResourceDownloadStoreInFolderTest.php
+++ b/tests/Unit/Internal/ResourceDownloadStoreInFolderTest.php
@@ -49,7 +49,6 @@ class ResourceDownloadStoreInFolderTest extends TestCase
     public function testCheckDestinationFolderWhenFolderExistsAndAskToNotCreate(): void
     {
         $downloader = $this->createResourceDownloadStoreInFolder(__DIR__);
-        /** @noinspection PhpUnhandledExceptionInspection */
         $downloader->checkDestinationFolder(false);
         $this->assertTrue(true, 'checkDestinationFolder should not create any exception');
     }
@@ -57,7 +56,6 @@ class ResourceDownloadStoreInFolderTest extends TestCase
     public function testCheckDestinationFolderWhenFolderExistsAndAskToCreate(): void
     {
         $downloader = $this->createResourceDownloadStoreInFolder(__DIR__);
-        /** @noinspection PhpUnhandledExceptionInspection */
         $downloader->checkDestinationFolder(true);
         $this->assertTrue(true, 'checkDestinationFolder should not create any exception');
     }
@@ -91,7 +89,6 @@ class ResourceDownloadStoreInFolderTest extends TestCase
         $destinationFolder = $this->filePath(uniqid());
         try {
             $downloader = $this->createResourceDownloadStoreInFolder($destinationFolder);
-            /** @noinspection PhpUnhandledExceptionInspection */
             $downloader->checkDestinationFolder(true);
             $this->assertDirectoryExists($destinationFolder);
         } finally {
@@ -115,7 +112,6 @@ class ResourceDownloadStoreInFolderTest extends TestCase
 
         $contents = 'foo-bar';
         $response = $this->createMock(ResponseInterface::class);
-        /** @noinspection PhpUnhandledExceptionInspection */
         $downloader->onSuccess($uuid, $contents, $response);
 
         try {

--- a/tests/Unit/Sessions/Ciec/CiecSessionDataTest.php
+++ b/tests/Unit/Sessions/Ciec/CiecSessionDataTest.php
@@ -18,9 +18,7 @@ final class CiecSessionDataTest extends TestCase
 
     private function createCaptchaResolver(): CaptchaResolverInterface
     {
-        /** @var CaptchaResolverInterface $captcha */
-        $captcha = $this->createMock(CaptchaResolverInterface::class);
-        return $captcha;
+        return $this->createMock(CaptchaResolverInterface::class);
     }
 
     public function testConstructWithEmptyRfc(): void

--- a/tests/Unit/Sessions/Ciec/CiecSessionManagerTest.php
+++ b/tests/Unit/Sessions/Ciec/CiecSessionManagerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
-
 declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Sessions\Ciec;

--- a/tests/Unit/Sessions/Fiel/CreateFakeFielTrait.php
+++ b/tests/Unit/Sessions/Fiel/CreateFakeFielTrait.php
@@ -10,11 +10,10 @@ trait CreateFakeFielTrait
 {
     private function createFakeFiel(): Credential
     {
-        $credential = Credential::openFiles(
+        return Credential::openFiles(
             $this->filePath('fake-fiel/EKU9003173C9.cer'),
             $this->filePath('fake-fiel/EKU9003173C9.key'),
             trim($this->fileContentPath('fake-fiel/EKU9003173C9.pwd')),
         );
-        return $credential;
     }
 }

--- a/tests/Unit/Sessions/Fiel/FielSessionManagerTest.php
+++ b/tests/Unit/Sessions/Fiel/FielSessionManagerTest.php
@@ -1,7 +1,5 @@
 <?php
 
-/** @noinspection PhpUnhandledExceptionInspection */
-
 declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Sessions\Fiel;


### PR DESCRIPTION
- Se creó la interfaz `SatScraperInterface` para que sea más fácil hacer mocks de esta librería.
- Se refactorizó `CaptchaBase64Extractor` para que use la lógica de `CaptchaImage`
- La clase `CaptchaBase64Extractor` es interna.
- Se implementó `@template` en `InputsGeneric`
- Se mejoró la lógica en el ejemplo de uso
- Se corrigieron múltiples issues menores encontrados por PhpStorm
- Se hizo una revisión a las excepciones, se hicieron algunas correcciones menores, se agregaron pruebas unitarias y se aseguró (manualmente) que las excepciones lanzadas por el código del proyecto fueran excepciones registradas y no estándar.
- Se revisaron las clases internas para que tengan una descripción y la anotación `@internal`