### PR TITLE
Documentación y correcciones pequeñas al CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
-# sudo-bot/action-scrutinizer@latest https://github.com/marketplace/actions/action-scrutinizer
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           fail-fast: true
       - name: Code style (phpcs)
-        run: phpcs -q --report=checkstyle src/ tests/ | cs2pr
+        run: phpcs -q --report=checkstyle | cs2pr
 
   php-cs-fixer:
     name: Code style (php-cs-fixer)

--- a/README.md
+++ b/README.md
@@ -456,6 +456,37 @@ $gateway = new SatHttpGateway($insecureClient);
 $scraper = new SatScraper($sessionManager, $gateway);
 ```
 
+## Problemas de conectividad con el SAT
+
+Es frecuente encontrar este problema dependiendo de la configuración general del sistema:
+
+```text
+cURL error 35: error:141A318A:SSL routines:tls_process_ske_dhe:dh key too small (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://cfdiau.sat.gob.mx/...
+```
+
+Este problema es por la configuración de los servidores que atienden las peticiones del SAT.
+
+Una forma de solucionar este problema únicamente para esta librería, consiste en establecer la configuración de cURL
+en el cliente del `SatHttpGateway` al crear el `SatScraper`:
+
+```php
+<?php declare(strict_types=1);
+use GuzzleHttp\Client;
+use PhpCfdi\CfdiSatScraper\SatHttpGateway;
+use PhpCfdi\CfdiSatScraper\SatScraper;
+use PhpCfdi\CfdiSatScraper\Sessions\SessionManager;
+
+$client = new Client([
+    'curl' => [CURLOPT_SSL_CIPHER_LIST => 'DEFAULT@SECLEVEL=1'],
+]);
+
+/** @var SessionManager $sessionManager */
+$scraper = new SatScraper($sessionManager, new SatHttpGateway($client));
+```
+
+Otra solución consiste en degradar la seguridad general de OpenSSL, algunas instrucciones se pueden ver en
+<https://askubuntu.com/questions/1250787/when-i-try-to-curl-a-website-i-get-ssl-error>.
+
 ## Compatibilidad
 
 Esta librería se mantendrá compatible con al menos la versión con

--- a/README.md
+++ b/README.md
@@ -417,6 +417,12 @@ use PhpCfdi\Credentials\Credential;
 
 // crear la credencial
 $credential = Credential::create($certificate, $privateKey, $passPhrase);
+if (! $credential->isFiel()) {
+    throw new Exception('The certificate and private key is not a FIEL');
+}
+if (! $credential->certificate()->validOn()) {
+    throw new Exception('The certificate and private key is not valid at this moment');
+}
 
 // crear el objeto scraper usando la FIEL
 $satScraper = new SatScraper(FielSessionManager::create($credential));
@@ -497,7 +503,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/phpcfdi/cfdi-sat-scraper?logo=php
 [badge-release]: https://img.shields.io/github/release/phpcfdi/cfdi-sat-scraper?logo=git
 [badge-license]: https://img.shields.io/github/license/phpcfdi/cfdi-sat-scraper?logo=open-source-initiative
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/cfdi-sat-scraper/build/main?style=flat-square
+[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/cfdi-sat-scraper/build/main?logo=github-actions
 [badge-reliability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_cfdi-sat-scraper&metric=reliability_rating
 [badge-maintainability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_cfdi-sat-scraper&metric=sqale_rating
 [badge-coverage]: https://img.shields.io/sonar/coverage/phpcfdi_cfdi-sat-scraper/main?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,18 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión.
 
+### Documentación 2022-03-01
+
+Se agrega la documentación para configurar el cliente de cURL con `DEFAULT@SECLEVEL=1`.
+
+Las pruebas se corren con `DEFAULT@SECLEVEL=1`.
+
+Se agrega el código que ejemplifica cómo validar que la FIEL no es un CSD y que es válido al momento de la consulta.
+
+### Entorno de desarrollo 2022-03-01
+
+Al ejecutar el flujo de integración continua, se usan los path en el archivo `phpcs.xml.dist`.
+
 ## Version 3.0.0
 
 Vea la [Guía de actualización de `2.x` a `3.x`](UPGRADE-2-3.md).

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,6 +4,7 @@
 
 - Core:
     - Incrementar las pruebas unitarias a un mínimo de 80%.
+    - Verificar si el SAT sigue teniendo problemas de conectividad y se puede usar `DEFAULT@SECLEVEL=2`.
 - Documentación:
     - Todos los puntos de entrada deben tener phpdoc.
 - Entorno de desarrollo:

--- a/tests/Integration/Factory.php
+++ b/tests/Integration/Factory.php
@@ -142,7 +142,7 @@ class Factory
         $stack->push(Middleware::history($container));
         return new Client([
             'handler' => $stack,
-            'curl' => [CURLOPT_SSL_CIPHER_LIST => 'DEFAULT@SECLEVEL=1']
+            'curl' => [CURLOPT_SSL_CIPHER_LIST => 'DEFAULT@SECLEVEL=1'],
         ]);
     }
 

--- a/tests/Integration/Factory.php
+++ b/tests/Integration/Factory.php
@@ -140,7 +140,10 @@ class Factory
         $container = new HttpLogger($this->path($this->env('SAT_HTTPDUMP_FOLDER')));
         $stack = HandlerStack::create();
         $stack->push(Middleware::history($container));
-        return new Client(['handler' => $stack]);
+        return new Client([
+            'handler' => $stack,
+            'curl' => [CURLOPT_SSL_CIPHER_LIST => 'DEFAULT@SECLEVEL=1']
+        ]);
     }
 
     public function createRepository(string $filename): Repository


### PR DESCRIPTION
Se agrega la documentación para configurar el cliente de cURL con `DEFAULT@SECLEVEL=1`.

Las pruebas se corren con `DEFAULT@SECLEVEL=1`.

Se agrega el código que ejemplifica cómo validar que la FIEL no es un CSD y que es válido al momento de la consulta.

Al ejecutar el flujo de integración continua, se usan los path en el archivo `phpcs.xml.dist`.
