### PR TITLE
Version 3.1.0

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.5.0" installed="3.5.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.4.2" installed="1.4.2" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.4.10" installed="1.4.10" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,12 +11,14 @@ declare(strict_types=1);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setCacheFile(__DIR__ . '/build/php_cs.cache')
+    ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
+        // PHP73Migration
+        'method_argument_space' => ['on_multiline' => 'ignore'],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Una vez dentro del sitio se pueden consultar facturas emitidas y facturas recibi
     - RFC Receptor.
     - Estado del comprobante (cualquiera, vigente o cancelado).
     - Tipo de comprobante (si contiene un complemento específico).
+    - RFC A cuenta de terceros.
 
 - Consulta de recibidas:
     - Fecha de emisión.
@@ -47,6 +48,7 @@ Una vez dentro del sitio se pueden consultar facturas emitidas y facturas recibi
     - RFC Emisor.
     - Estado del comprobante (cualquiera, vigente o cancelado).
     - Tipo de comprobante (si contiene un complemento específico).
+    - RFC A cuenta de terceros.
 
 El servicio de búsqueda regresa una tabla con información, con un tope de 500 registros por consulta
 (aun cuando existan más, solo se muestran 500).
@@ -149,6 +151,7 @@ use PhpCfdi\CfdiSatScraper\QueryByFilters;
 use PhpCfdi\CfdiSatScraper\Filters\Options\ComplementsOption;
 use PhpCfdi\CfdiSatScraper\Filters\DownloadType;
 use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
+use PhpCfdi\CfdiSatScraper\Filters\Options\RfcOnBehalfOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\RfcOption;
 
 // se crea con un rango de fechas específico
@@ -158,6 +161,7 @@ $query
     ->setStateVoucher(StatesVoucherOption::vigentes())          // en lugar de todos
     ->setRfc(new RfcOption('EKU9003173C9'))                     // de este RFC específico
     ->setComplement(ComplementsOption::reciboPagoSalarios12())  // que incluya este complemento
+    ->setRfcOnBehalf(new RfcOnBehalfOption('AAA010101AAA'))     // con este RFC A cuenta de terceros
 ;
 ```
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,18 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión.
 
+## Version 3.1.0
+
+### Agregar *RFC a cuenta de terceros*
+
+Se agrega el filtro `RfcOnBehalfOption`.
+Se agrega la lectura de esta información en `Metadata` como `rfcACuentaTerceros`.
+Se agrega la documentación para filtrar y leer el campo de *RFC a cuenta de terceros*.
+
+### Acceso por propiedades a `Metadata`.
+
+Se documentan las propiedades en `Metadata` para acceder a ellas usando, por ejemplo `$metadata->uuid`.
+
 ### Documentación 2022-03-01
 
 Se agrega la documentación para configurar el cliente de cURL con `DEFAULT@SECLEVEL=1`.

--- a/src/Filters/Options/ComplementsOption.php
+++ b/src/Filters/Options/ComplementsOption.php
@@ -15,6 +15,8 @@ use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
  * @method static self sinComplemento()
  * @method static self acreditamientoIeps()
  * @method static self aerolineas()
+ * @method static self cartaPorte10()
+ * @method static self cartaPorte20()
  * @method static self certificadoDestruccion()
  * @method static self comercioExterior()
  * @method static self comercioExterior11()
@@ -37,6 +39,7 @@ use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
  * @method static self pagoEspecie()
  * @method static self personaFisicaIntegranteCoordinado()
  * @method static self recepcionPagos()
+ * @method static self recepcionPagos20()
  * @method static self reciboDonativo()
  * @method static self reciboPagoSalarios()
  * @method static self reciboPagoSalarios12()
@@ -56,6 +59,8 @@ use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
  * @method bool isSinComplemento()
  * @method bool isAcreditamientoIeps()
  * @method bool isAerolineas()
+ * @method bool isCartaPorte10()
+ * @method bool isCartaPorte20()
  * @method bool isCertificadoDestruccion()
  * @method bool isComercioExterior()
  * @method bool isComercioExterior11()
@@ -78,6 +83,7 @@ use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
  * @method bool isPagoEspecie()
  * @method bool isPersonaFisicaIntegranteCoordinado()
  * @method bool isRecepcionPagos()
+ * @method bool isRecepcionPagos20()
  * @method bool isReciboDonativo()
  * @method bool isReciboPagoSalarios()
  * @method bool isReciboPagoSalarios12()
@@ -114,6 +120,14 @@ class ComplementsOption extends MicroCatalog implements FilterOption
         'aerolineas' => [
             'input' => '8388608',
             'description' => 'Aerolíneas',
+        ],
+        'cartaPorte10' => [
+            'input' => '70368744177664',
+            'description' => 'Carta Porte 1.0',
+        ],
+        'cartaPorte20' => [
+            'input' => '140737488355328',
+            'description' => 'Carta Porte 2.0',
         ],
         'certificadoDestruccion' => [
             'input' => '1073741824',
@@ -201,7 +215,11 @@ class ComplementsOption extends MicroCatalog implements FilterOption
         ],
         'recepcionPagos' => [
             'input' => '549755813888',
-            'description' => 'Complemento para recepción de pagos',
+            'description' => 'Recepción de pagos',
+        ],
+        'recepcionPagos20' => [
+            'input' => '1125899906842624',
+            'description' => 'Recepción de pagos 2.0',
         ],
         'reciboDonativo' => [
             'input' => '128',

--- a/src/Filters/Options/RfcOnBehalfOption.php
+++ b/src/Filters/Options/RfcOnBehalfOption.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Filters\Options;
+
+use PhpCfdi\CfdiSatScraper\Contracts\FilterOption;
+
+/**
+ * RfcOnBehalfOption (A cuenta de terceros) option
+ */
+class RfcOnBehalfOption implements FilterOption
+{
+    /** @var string */
+    protected $value;
+
+    public function __construct(string $rfc)
+    {
+        $this->value = mb_strtoupper($rfc);
+    }
+
+    public function nameIndex(): string
+    {
+        return 'ctl00$MainContent$TxtRfcTercero';
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Filters/Options/RfcOption.php
+++ b/src/Filters/Options/RfcOption.php
@@ -16,7 +16,7 @@ class RfcOption implements FilterOption
 
     public function __construct(string $rfc)
     {
-        $this->value = $rfc;
+        $this->value = mb_strtoupper($rfc);
     }
 
     public function nameIndex(): string

--- a/src/Inputs/InputsByFilters.php
+++ b/src/Inputs/InputsByFilters.php
@@ -37,7 +37,12 @@ abstract class InputsByFilters extends InputsGeneric implements InputsInterface
     {
         /** @var QueryByFilters $query */
         $query = $this->getQuery();
-        return [$query->getComplement(), $query->getStateVoucher(), $query->getRfc()];
+        return [
+            $query->getComplement(),
+            $query->getStateVoucher(),
+            $query->getRfc(),
+            $query->getRfcOnBehalf(),
+        ];
     }
 
     /**

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -60,7 +60,10 @@ class MetadataExtractor
         return new MetadataList($data);
     }
 
-    /** @return array<string, string> */
+    /**
+     * @return array<string, string>
+     * @see Metadata
+     */
     public function defaultFieldsCaptions(): array
     {
         return [
@@ -78,6 +81,7 @@ class MetadataExtractor
             'estadoComprobante' => 'Estado del Comprobante',
             'estatusProcesoCancelacion' => 'Estatus de Proceso de Cancelación',
             'fechaProcesoCancelacion' => 'Fecha de Proceso de Cancelación',
+            'rfcACuentaTerceros' => 'RFC a cuenta de terceros',
         ];
     }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -4,16 +4,40 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper;
 
+use ArrayIterator;
+use IteratorAggregate;
 use JsonSerializable;
+use LogicException;
 use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
+use PhpCfdi\CfdiSatScraper\Internal\MetadataExtractor;
+use Traversable;
 
 /**
  * The Metadata class is a storage of values retrieved from the list of documents obtained from
  * a search on the SAT CFDI Portal.
  *
  * It always has a UUID, all other properties are optional.
+ *
+ * @property-read string $uuid Folio Fiscal
+ * @property-read string $rfcEmisor RFC Emisor
+ * @property-read string $nombreEmisor Nombre o Razón Social del Emisor
+ * @property-read string $rfcReceptor RFC Receptor
+ * @property-read string $nombreReceptor Nombre o Razón Social del Receptor
+ * @property-read string $fechaEmision Fecha de Emisión
+ * @property-read string $fechaCertificacion Fecha de Certificación
+ * @property-read string $pacCertifico PAC que Certificó
+ * @property-read string $total Total
+ * @property-read string $efectoComprobante Efecto del Comprobante
+ * @property-read string $estatusCancelacion Estatus de cancelación
+ * @property-read string $estadoComprobante Estado del Comprobante
+ * @property-read string $estatusProcesoCancelacion Estatus de Proceso de Cancelación
+ * @property-read string $fechaProcesoCancelacion Fecha de Proceso de Cancelación
+ * @property-read string $rfcACuentaTerceros RFC a cuenta de terceros
+ *
+ * @see MetadataExtractor::defaultFieldsCaptions()
+ * @implements IteratorAggregate<string, string>
  */
-class Metadata implements JsonSerializable
+class Metadata implements JsonSerializable, IteratorAggregate
 {
     /** @var array<string, string> */
     private $data;
@@ -35,6 +59,27 @@ class Metadata implements JsonSerializable
         $this->data = ['uuid' => strtolower($uuid)] + $data;
     }
 
+    public function __get(string $name): string
+    {
+        return $this->get($name);
+    }
+
+    public function __isset(string $name): bool
+    {
+        return $this->has($name);
+    }
+
+    /** @param mixed $value */
+    public function __set(string $name, $value): void
+    {
+        throw new LogicException(sprintf('The %s class is immutable', self::class));
+    }
+
+    public function __unset(string $name): void
+    {
+        throw new LogicException(sprintf('The %s class is immutable', self::class));
+    }
+
     public function uuid(): string
     {
         return $this->data['uuid'];
@@ -43,6 +88,12 @@ class Metadata implements JsonSerializable
     public function get(string $key): string
     {
         return strval($this->data[$key] ?? '');
+    }
+
+    /** @return array<string, string> */
+    public function getData(): array
+    {
+        return $this->data;
     }
 
     public function has(string $key): bool
@@ -58,6 +109,12 @@ class Metadata implements JsonSerializable
     public function hasResource(ResourceType $resourceType): bool
     {
         return $this->has($resourceType->value());
+    }
+
+    /** @return Traversable<string, string> */
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->data);
     }
 
     /** @return array<string, string> */

--- a/src/QueryByFilters.php
+++ b/src/QueryByFilters.php
@@ -9,6 +9,7 @@ use PhpCfdi\CfdiSatScraper\Contracts\QueryInterface;
 use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
 use PhpCfdi\CfdiSatScraper\Filters\DownloadType;
 use PhpCfdi\CfdiSatScraper\Filters\Options\ComplementsOption;
+use PhpCfdi\CfdiSatScraper\Filters\Options\RfcOnBehalfOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\RfcOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\StatesVoucherOption;
 use PhpCfdi\CfdiSatScraper\Internal\DownloadTypePropertyTrait;
@@ -29,6 +30,9 @@ class QueryByFilters implements QueryInterface
     /** @var RfcOption */
     private $rfc;
 
+    /** @var RfcOnBehalfOption */
+    private $rfcOnBehalf;
+
     /** @var ComplementsOption */
     private $complement;
 
@@ -47,6 +51,7 @@ class QueryByFilters implements QueryInterface
         $this->setComplement(ComplementsOption::todos());
         $this->setStateVoucher(StatesVoucherOption::todos());
         $this->setRfc(new RfcOption(''));
+        $this->setRfcOnBehalf(new RfcOnBehalfOption(''));
     }
 
     /**
@@ -118,12 +123,30 @@ class QueryByFilters implements QueryInterface
 
     /**
      * @param RfcOption $rfc
-     *
      * @return $this
      */
     public function setRfc(RfcOption $rfc): self
     {
         $this->rfc = $rfc;
+
+        return $this;
+    }
+
+    /**
+     * @return RfcOnBehalfOption
+     */
+    public function getRfcOnBehalf(): RfcOnBehalfOption
+    {
+        return $this->rfcOnBehalf;
+    }
+
+    /**
+     * @param RfcOnBehalfOption $rfcOnBehalf
+     * @return $this
+     */
+    public function setRfcOnBehalf(RfcOnBehalfOption $rfcOnBehalf): self
+    {
+        $this->rfcOnBehalf = $rfcOnBehalf;
 
         return $this;
     }

--- a/tests/Unit/Internal/MetadataExtractorTest.php
+++ b/tests/Unit/Internal/MetadataExtractorTest.php
@@ -167,6 +167,28 @@ final class MetadataExtractorTest extends TestCase
         $this->assertCount(1, $list);
         $expectedUuid = 'B97262E5-704C-4BF7-AE26-9174FEF04D63';
         $this->assertTrue($list->has($expectedUuid));
+        $expectedData = [
+            'uuid' => 'b97262e5-704c-4bf7-ae26-9174fef04d63',
+            'rfcEmisor' => 'BSM970519DU8',
+            'nombreEmisor' => 'BANCO SANTANDER MEXICO, SA INSTITUCION DE BANCA MULTIPLE, GRUPO FINANCIERO SANTANDER MEXICO',
+            'rfcReceptor' => 'AUAC920422D38',
+            'nombreReceptor' => 'CESAR RENE AGUILERA ARREOLA',
+            'fechaEmision' => '2019-03-31T02:04:46',
+            'fechaCertificacion' => '2019-03-31T02:05:15',
+            'pacCertifico' => 'INT020124V62',
+            'total' => '$0.00',
+            'efectoComprobante' => 'Ingreso',
+            'estatusCancelacion' => 'Cancelable sin aceptación',
+            'estadoComprobante' => 'Vigente',
+            'estatusProcesoCancelacion' => '',
+            'fechaProcesoCancelacion' => '',
+            'rfcACuentaTerceros' => 'AAA991231AAA',
+            'urlXml' => '', // the data is not included on test file
+            'urlPdf' => '',
+            'urlCancelRequest' => '',
+            'urlCancelVoucher' => '',
+        ];
+        $this->assertSame($expectedData, $list->get($expectedUuid)->getData());
     }
 
     public function testExtractUsingSampleWithOneUuid(): void
@@ -197,6 +219,7 @@ final class MetadataExtractorTest extends TestCase
                 'estadoComprobante' => 'Vigente',
                 'estatusProcesoCancelacion' => '',
                 'fechaProcesoCancelacion' => '',
+                'rfcACuentaTerceros' => 'ABC010101AAA',
             ],
         ];
 

--- a/tests/Unit/QueryByFiltersTest.php
+++ b/tests/Unit/QueryByFiltersTest.php
@@ -88,4 +88,13 @@ final class QueryByFiltersTest extends TestCase
 
         $this->assertEquals($query->getRfc()->value(), $rfc);
     }
+
+    public function testSetRfcOnBehalfOption(): void
+    {
+        $rfc = 'ABGC930521D34';
+        $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
+        $this->assertSame($query, $query->setRfcOnBehalf(new RfcOnBehalfOption($rfc)), 'The setter should be fluid');
+
+        $this->assertEquals($query->getRfcOnBehalf()->value(), $rfc);
+    }
 }

--- a/tests/Unit/QueryByFiltersTest.php
+++ b/tests/Unit/QueryByFiltersTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use PhpCfdi\CfdiSatScraper\Filters\DownloadType;
 use PhpCfdi\CfdiSatScraper\Filters\Options\ComplementsOption;
+use PhpCfdi\CfdiSatScraper\Filters\Options\RfcOnBehalfOption;
 use PhpCfdi\CfdiSatScraper\Filters\Options\RfcOption;
 use PhpCfdi\CfdiSatScraper\QueryByFilters as Query;
 use PhpCfdi\CfdiSatScraper\Tests\TestCase;
@@ -44,7 +45,7 @@ final class QueryByFiltersTest extends TestCase
         $end = new DateTimeImmutable('2019-01-17');
 
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
-        $query->setPeriod($start, $end);
+        $this->assertSame($query, $query->setPeriod($start, $end), 'The setter should be fluid');
 
         $this->assertEquals($query->getStartDate(), $start);
         $this->assertEquals($query->getEndDate(), $end);
@@ -56,8 +57,8 @@ final class QueryByFiltersTest extends TestCase
         $end = new DateTimeImmutable('2019-01-17');
 
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
-        $query->setStartDate($start);
-        $query->setEndDate($end);
+        $this->assertSame($query, $query->setStartDate($start), 'The setter should be fluid');
+        $this->assertSame($query, $query->setEndDate($end), 'The setter should be fluid');
 
         $this->assertEquals($query->getStartDate(), $start);
         $this->assertEquals($query->getEndDate(), $end);
@@ -66,7 +67,7 @@ final class QueryByFiltersTest extends TestCase
     public function testSetComplementOption(): void
     {
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
-        $query->setComplement(ComplementsOption::aerolineas());
+        $this->assertSame($query, $query->setComplement(ComplementsOption::aerolineas()), 'The setter should be fluid');
 
         $this->assertTrue($query->getComplement()->isAerolineas());
     }
@@ -74,7 +75,7 @@ final class QueryByFiltersTest extends TestCase
     public function testSetDownloadTypeOption(): void
     {
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
-        $query->setDownloadType(DownloadType::recibidos());
+        $this->assertSame($query, $query->setDownloadType(DownloadType::recibidos()), 'The setter should be fluid');
 
         $this->assertTrue($query->getDownloadType()->isRecibidos());
     }
@@ -83,7 +84,7 @@ final class QueryByFiltersTest extends TestCase
     {
         $rfc = 'ABGC930521D34';
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
-        $query->setRfc(new RfcOption($rfc));
+        $this->assertSame($query, $query->setRfc(new RfcOption($rfc)), 'The setter should be fluid');
 
         $this->assertEquals($query->getRfc()->value(), $rfc);
     }

--- a/tests/_files/fake-to-extract-metadata-missing-uuid.html
+++ b/tests/_files/fake-to-extract-metadata-missing-uuid.html
@@ -17,6 +17,7 @@
                 <th><span>Estado del Comprobante</span></th>
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
+                <th><span>RFC a cuenta de terceros</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -34,6 +35,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -51,6 +53,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -68,6 +71,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>
     </body>

--- a/tests/_files/fake-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-one-cfdi.html
@@ -17,6 +17,7 @@
                 <th><span>Estado del Comprobante</span></th>
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
+                <th><span>RFC a cuenta de terceros</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -34,6 +35,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">AAA991231AAA</span></td>
             </tr>
         </table>
     </body>

--- a/tests/_files/fake-to-extract-metadata-ten-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-ten-cfdi.html
@@ -17,6 +17,7 @@
                 <th><span>Estado del Comprobante</span></th>
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
+                <th><span>RFC a cuenta de terceros</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -34,6 +35,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -51,6 +53,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -68,6 +71,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -85,6 +89,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -102,6 +107,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -119,6 +125,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -136,6 +143,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -170,6 +178,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -187,6 +196,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>
     </body>

--- a/tests/_files/fake-to-extract-metadata-zero-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-zero-cfdi.html
@@ -17,6 +17,7 @@
                 <th><span>Estado del Comprobante</span></th>
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
+                <th><span>RFC a cuenta de terceros</span></th>
             </tr>
         </table>
     </body>

--- a/tests/_files/sample-response-receiver-using-filters-initial.html
+++ b/tests/_files/sample-response-receiver-using-filters-initial.html
@@ -558,21 +558,28 @@
 
                 
                     <div class="form-group">
-                        <div class="col-sm-6">
+                        <div class="col-sm-4">
                             <span id="ctl00_MainContent_LblRfcReceptor" class="control-label">RFC Emisor</span>
                         </div>
-                        <div class="col-sm-6">
+                        <div class="col-sm-4">
+                            <span id="ctl00_MainContent_LblRfcTercero" class="control-label">RFC a cuenta terceros</span>
+                        </div>
+                        <div class="col-sm-4">
                             <span id="ctl00_MainContent_LblEstado" class="control-label">Estado del Comprobante</span>
                         </div>
                     </div>
-                
 
-                
+
+
                     <div class="form-group">
-                        <div class="col-md-6">
+                        <div class="col-md-4">
                             <input name="ctl00$MainContent$TxtRfcReceptor" type="text" maxlength="13" id="ctl00_MainContent_TxtRfcReceptor" class="form-control" />
+
                         </div>
-                        <div class="col-md-6">
+                        <div class="col-md-4">
+                            <input name="ctl00$MainContent$TxtRfcTercero" type="text" maxlength="13" id="ctl00_MainContent_TxtRfcTercero" class="form-control" style="width:100%;" />
+                        </div>
+                        <div class="col-md-4">
                             <select name="ctl00$MainContent$DdlEstadoComprobante" id="ctl00_MainContent_DdlEstadoComprobante" class="form-control" onchange="EstadoComprobante(this);">
 	<option value="-1">Seleccione un valor...</option>
 	<option value="0">Cancelado</option>

--- a/tests/_files/sample-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/sample-to-extract-metadata-one-cfdi.html
@@ -755,6 +755,9 @@
 			<th>
                                         <span style="width: 200px;">Fecha de Proceso de Cancelación</span>
                                     </th>
+			<th>
+                                        <span style="width: 200px;">RFC a cuenta de terceros</span>
+                                    </th>
 		</tr>
 		<tr>
 			<td><div style="width:150px; display:block;text-align:center;vertical-align:middle; position: relative;"><table>
@@ -786,7 +789,8 @@
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-		</tr>
+            <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;">ABC010101AAA</span></td>
+        </tr>
         <tr>
             <td>
                 <div style="width:150px; display:block;text-align:rigth;vertical-align:middle; position: relative;">


### PR DESCRIPTION
### Agregar *RFC a cuenta de terceros*

Se agrega el filtro `RfcOnBehalfOption`.
Se agrega la lectura de esta información en `Metadata` como `rfcACuentaTerceros`.
Se agrega la documentación para filtrar y leer el campo de *RFC a cuenta de terceros*.

### Acceso por propiedades a `Metadata`.

Se documentan las propiedades en `Metadata` para acceder a ellas usando, por ejemplo `$metadata->uuid`.

### Documentación 2022-03-01

Se agrega la documentación para configurar el cliente de cURL con `DEFAULT@SECLEVEL=1`.

Las pruebas se corren con `DEFAULT@SECLEVEL=1`.

Se agrega el código que ejemplifica cómo validar que la FIEL no es un CSD y que es válido al momento de la consulta.

### Entorno de desarrollo 2022-03-01

Al ejecutar el flujo de integración continua, se usan los path en el archivo `phpcs.xml.dist`.

