### PR TITLE
Mantenimiento 2022-07-14 (versión 3.1.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
@@ -34,13 +34,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
@@ -51,11 +51,11 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2, phpstan
         env:
@@ -64,7 +64,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -82,7 +82,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -95,7 +95,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,15 +10,15 @@ on:
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.0 (code coverage)
+    name: Tests on PHP 8.1 (code coverage)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: xdebug
           tools: composer:v2
         env:
@@ -27,7 +27,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -37,7 +37,7 @@ jobs:
       - name: Create code coverage
         run: vendor/bin/phpunit --testsuite=complete --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: code-coverage
           path: build/coverage
@@ -72,20 +72,20 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -93,7 +93,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: code-coverage
           path: build/coverage

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.4.10" installed="1.4.10" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.9.3" installed="3.9.3" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.8.1" installed="1.8.1" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -25,9 +25,7 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
-        'new_with_braces' => true,
-        'no_blank_lines_after_class_opening' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'arguments']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -36,7 +34,6 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
-        'no_whitespace_in_blank_line' => true,
         'yoda_style' => ['equal' => true, 'identical' => true, 'less_and_greater' => null],
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
@@ -46,10 +43,7 @@ return (new PhpCsFixer\Config())
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
-        'single_blank_line_before_namespace' => true,
-        'blank_line_after_opening_tag' => true,
-        'ordered_imports' => true,
-        'array_syntax' => ['syntax' => 'short'],
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Si se llega a la consulta mínima de 1 segundo y se obtuvieron 500 o más regist
 se llama a un *callback* (opcional) para reportar este acontecimiento.
 
 La búsqueda siempre debe crearse con un rango de fechas, además en forma predeterminada, se busca por CFDI emitidos,
-con cualquier complemento y con cualquier estado (vigente o cancelado). Sin embargo puedes cambiar la búsqueda antes
+con cualquier complemento y con cualquier estado (vigente o cancelado). Sin embargo, puedes cambiar la búsqueda antes
 de enviar a procesarla.
 
 Esta librería está basada en [Guzzle](https://github.com/guzzle/guzzle), por lo que puedes configurar el cliente
@@ -377,7 +377,7 @@ $satScraper = new SatScraper(CiecSessionManager::create('rfc', 'ciec', $captchaR
 El siguiente ejemplo muestra cómo usar el método `SatScraper::confirmSessionIsAlive` para verificar que
 los datos de sesión sean (o continuen siendo) correctos. El funcionamiento interno del scraper es:
 Si la sesión no se inicializó previamente entonces se intentará hacer el proceso de autenticación,
-además se verificará que la sesión (`cookie`) se encuentre vigente.
+además se comprobará que la sesión (`cookie`) se encuentre vigente.
 
 Se hacen los dos pasos para evitar consumir el servicio de resolución de captcha en forma innecesaria.
 
@@ -405,6 +405,10 @@ El siguiente ejemplo utiliza una FIEL donde los archivos de certificado y llave 
 en memoria y se encuentran vigentes. Puede obtener más información de cómo formar la credencial en
 el proyecto [`phpcfdi/credentials`](https://github.com/phpcfdi/credentials).
 
+Para crear la credencial se necesita un certificado, una llave privada y la contraseña.
+Si el contenido del certificado y llave privada están en memoria, se utiliza el método `Credential::create()`. 
+Si el certificado y llave privada están en archivos, se emplea el método `Credential::openFiles()`. 
+
 ```php
 <?php declare(strict_types=1);
 
@@ -420,6 +424,7 @@ use PhpCfdi\Credentials\Credential;
  */
 
 // crear la credencial
+// se puede usar Credential::openFiles(certificateFile, privateKeyFile, passphrase) si la FIEL está en archivos 
 $credential = Credential::create($certificate, $privateKey, $passPhrase);
 if (! $credential->isFiel()) {
     throw new Exception('The certificate and private key is not a FIEL');

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "ext-fileinfo": "*",
+        "ext-mbstring": "*",
         "ext-openssl": "*",
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": "^7.0",

--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,8 @@
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/promises": "^1.3",
-        "symfony/dom-crawler": "^5.1",
-        "symfony/css-selector": "^5.1",
+        "symfony/dom-crawler": "^5.4|^6.0",
+        "symfony/css-selector": "^5.4|^6.0",
         "eclipxe/enum": "^0.2.0",
         "eclipxe/micro-catalog": "^0.1.2",
         "phpcfdi/credentials": "^1.1",
@@ -50,7 +50,7 @@
     "require-dev": {
         "ext-iconv": "*",
         "phpunit/phpunit": "^9.5",
-        "symfony/dotenv": "^5.1",
+        "symfony/dotenv": "^5.4|^6.0",
         "fakerphp/faker": "^1.13"
     },
     "scripts": {

--- a/develop/ComoFunciona.md
+++ b/develop/ComoFunciona.md
@@ -25,7 +25,7 @@ para crear los inputs (datos de las llamadas HTTP POST) basados en la consulta. 
 encargado de definir cuál es la implementación de `InputsInterface` que utilizará: `InputsByUuid`,
 `InputsByFiltersReceived` y `InputsByFiltersIssued`.
 
-```
+```text
 - interface InputsInterface
     - abstract InputsGeneric
         - concrete InputsByUuid
@@ -43,7 +43,7 @@ La resolución de una consulta de `QueryResolver` consta de 3 pasos:
 
 Por lo anterior, los pasos son:
 
-```
+```text
 SatScraper -> MetadataDownloader -> QueryResolver
           Query          Query[] -> Inputs
 ```

--- a/develop/TestIntegracion.md
+++ b/develop/TestIntegracion.md
@@ -86,7 +86,7 @@ xdg-open http://127.0.0.1:9595
 
 Y para ejecutar los tests:
 
-```
+```shell
 # using .env config
 php vendor/bin/phpunit --testsuite integration --verbose
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión.
 
-## Version 3.1.0
+## Versión 3.1.0
 
 ### Agregar *RFC a cuenta de terceros*
 
@@ -30,7 +30,7 @@ Se agrega el código que ejemplifica cómo validar que la FIEL no es un CSD y qu
 
 Al ejecutar el flujo de integración continua, se usan los path en el archivo `phpcs.xml.dist`.
 
-## Version 3.0.0
+## Versión 3.0.0
 
 Vea la [Guía de actualización de `2.x` a `3.x`](UPGRADE-2-3.md).
 
@@ -53,7 +53,7 @@ Cambios relevantes en desarrollo:
   <https://sonarcloud.io/project/overview?id=phpcfdi_cfdi-sat-scraper>.
 - Se deja de usar la integración con Scrutinizer CI. Gracias Srutinizer.
 
-## Version 2.1.1
+## Versión 2.1.1
 
 Se corrige un bug al consumir el servicio de Anti-Captcha donde estaba asumiendo que el código de error
 era un string vacío cuando en realidad es un número entero.
@@ -63,7 +63,7 @@ era un string vacío cuando en realidad es un número entero.
 
 - 2021-07-05: CI: Se permite que falle la subida del archivo de cobertura de código a Scrutinizer-CI.
 
-## Version 2.1.0
+## Versión 2.1.0
 
 Se agrega la implementación para resolver el *captcha* en la clase `AntiCaptchaResolver`,
 que a su vez usa la clase `AntiCaptchaTinyClient` como un cliente de conectividad mínimo.
@@ -74,7 +74,7 @@ Estos cambios no son importantes si estás usando la librería y son con respect
 Los flujos de pruebas de integración contínua ahora se migraron a GitHub Actions,
 Travis-CI ha sido de gran ayuda en el desarrollo de este proyecto.
 
-## Version 2.0.0
+## Versión 2.0.0
 
 ### Descarga de diferentes tipos de recursos
 
@@ -101,7 +101,7 @@ Este cambio no afectó la versión liberada y no requiere de un nuevo release.
   de PHPUnit, por lo que sabe que el código subsecuente es código muerto. Se corrigieron las pruebas con problemas.
 - Se actualizó la herramienta `develop/install-development-tools`
 
-## Version 1.0.1
+## Versión 1.0.1
 
 - Se actualizan dependencias:
     - `symfony/dom-crawler` de `^4.2|^5.0` a `5.1`.
@@ -113,7 +113,7 @@ Este cambio no afectó la versión liberada y no requiere de un nuevo release.
 - Se cambia en desarrollo la inicialización de `Dotenv` porque se deprecó la forma anterior en `symfony/dotenv: ^5.1`.
 - Se cambia en desarrollo la dependencia de `symfony/dotenv` de `^4.2|^5.0` a `^5.1`.
 
-## Version 1.0.0
+## Versión 1.0.0
 
 - Se establece la versión mínima de PHP a 7.3.
 - Se revisan las expresiones regulares y `json_encode`/`json_decode` con el paso a 7.3.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,28 @@
 
 Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta librería sin temor a romper tu aplicación.
 
-## Cambios aún no liberados en una versión.
+## Cambios aún no liberados en una versión
+
+No hay cambios no liberados, si existen, deben aparecer aquí.
+
+## Versión 3.1.1
+
+### Cambios en el código
+
+Se admite la compatibilidad con Symfony 6. Esto evita que se tengan que degradar componentes a la versión 5.
+
+Se depreca `SatHttpGatewayException::postLoginData` para crear el método específico
+`SatHttpGatewayException::postCiecLoginData`. Esto no altera la funcionalidad actual.
+
+Se agrega la dependencia faltante `mbstring`.
+
+### Cambios en el entorno de desarrollo
+
+Se mejoran los test para probar valores idénticos en lugar de valores iguales.
+
+Se actualizan las herramientas de desarrollo.
+
+Se actualiza el archivo de configuración de `php-cs-fixer`. 
 
 ## Versión 3.1.0
 

--- a/docs/SEMVER.md
+++ b/docs/SEMVER.md
@@ -26,7 +26,7 @@ Esto significa que:
 ## Versiones 0.x.y no rompe compatibilidad
 
 Las versiones que inician con cero, por ejemplo `0.y.z`, no se ajustan a las reglas de versionado.
-Se considera que estas versiones son previas a la madurez del proyecto y por lo tanto
+Se considera que estas versiones son previas a la madurez del proyecto y, por lo tanto,
 introducen cambios sin previo aviso.
 
 ## `@internal` no rompe compatibilidad

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,5 +1,9 @@
 # phpcfdi/cfdi-sat-scraper tareas pendientes
 
+## Siguiente versión mayor
+
+- Eliminar el método `SatHttpGatewayException::postLoginData`.
+
 ## Pendientes
 
 - Core:

--- a/docs/UPGRADE-2-3.md
+++ b/docs/UPGRADE-2-3.md
@@ -2,7 +2,7 @@
 
 ## Creación del objeto `SatScraper`
 
-Anteriormente el objeto `SatScraper` se construía utilizando los datos de la Clave CIEC,
+Anteriormente, el objeto `SatScraper` se construía utilizando los datos de la Clave CIEC,
 sin embargo, a partir de la versión 3 se puede utilizar la Clave CIEC o la FIEL.
 
 Luego entonces, esta es la nueva forma de construirlo:
@@ -42,7 +42,7 @@ se incluye el método `getCaptchaImage` con el último objeto `CaptchaImage` que
 
 ## Manejador del momento cuando se han alcanzado 500 registros
 
-Anteriormente se usaba una función `callable` con la firma `callable(DateTimeImmutable): void`.
+Anteriormente, se usaba una función `callable` con la firma `callable(DateTimeImmutable): void`.
 
 Ahora se requiere una implementación del *contrato* `MaximumRecordsHandler`.
 Si al crear el objeto `SatScraper` no se establece un manejador o se establece como `null` entonces se usará

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,9 @@
     defaultTestSuite="unit"
     bootstrap="tests/bootstrap.php"
     cacheResultFile="build/phpunit.result.cache"
-    colors="true">
+    convertDeprecationsToExceptions="true"
+    colors="true"
+    >
 
   <coverage>
     <include>

--- a/src/SatHttpGateway.php
+++ b/src/SatHttpGateway.php
@@ -86,12 +86,28 @@ class SatHttpGateway
      * @param array<string, string> $formParams
      * @return string
      * @throws SatHttpGatewayException
-     * @todo rename to postCiecLoginData
      */
-    public function postLoginData(string $loginUrl, array $formParams): string
+    public function postCiecLoginData(string $loginUrl, array $formParams): string
     {
         $headers = Headers::post($this->urlHost(URLS::AUTH_LOGIN), URLS::AUTH_LOGIN);
         return $this->post('post login data', $loginUrl, $headers, $formParams);
+    }
+
+    /**
+     * @param string $loginUrl
+     * @param array<string, string> $formParams
+     * @return string
+     * @throws SatHttpGatewayException
+     * @deprecated 3.1.1
+     * @see SatHttpGateway::postCiecLoginData()
+     */
+    public function postLoginData(string $loginUrl, array $formParams): string
+    {
+        trigger_error(
+            sprintf('Method %1$s::postLoginData is deprecated, use %1$s::postCiecLoginData', static::class),
+            E_USER_DEPRECATED,
+        );
+        return $this->postCiecLoginData($loginUrl, $formParams);
     }
 
     /**

--- a/src/Sessions/Ciec/CiecSessionManager.php
+++ b/src/Sessions/Ciec/CiecSessionManager.php
@@ -131,7 +131,7 @@ final class CiecSessionManager extends AbstractSessionManager implements Session
             'userCaptcha' => $captchaValue,
         ];
         try {
-            $response = $this->getHttpGateway()->postLoginData(URLS::AUTH_LOGIN, $postData);
+            $response = $this->getHttpGateway()->postCiecLoginData(URLS::AUTH_LOGIN, $postData);
         } catch (SatHttpGatewayException $exception) {
             throw CiecLoginException::connectionException('sending login data', $this->sessionData, $exception);
         }

--- a/src/Sessions/Fiel/FielSessionManager.php
+++ b/src/Sessions/Fiel/FielSessionManager.php
@@ -59,7 +59,7 @@ final class FielSessionManager extends AbstractSessionManager implements Session
             $httpGateway->getPortalMainPage();
 
             // previous page will try to redirect to access by password using post
-            $httpGateway->postLoginData(URLS::AUTH_LOGIN_CIEC, []);
+            $httpGateway->postCiecLoginData(URLS::AUTH_LOGIN_CIEC, []);
 
             // change to fiel login page and get challenge
             $html = $httpGateway->getAuthLoginPage(URLS::AUTH_LOGIN_FIEL, URLS::AUTH_LOGIN_CIEC);

--- a/tests/Integration/Repository.php
+++ b/tests/Integration/Repository.php
@@ -148,7 +148,7 @@ class Repository implements Countable, IteratorAggregate, JsonSerializable
     }
 
     /** @return Traversable<string, RepositoryItem> */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         return new ArrayIterator($this->items);
     }
@@ -156,6 +156,6 @@ class Repository implements Countable, IteratorAggregate, JsonSerializable
     /** @return RepositoryItem[] */
     public function jsonSerialize(): array
     {
-        return iterator_to_array($this->getIterator());
+        return $this->items;
     }
 }

--- a/tests/Unit/QueryByFiltersTest.php
+++ b/tests/Unit/QueryByFiltersTest.php
@@ -35,8 +35,8 @@ final class QueryByFiltersTest extends TestCase
         $end = new DateTimeImmutable('2019-01-31');
         $query = new Query($start, $end);
 
-        $this->assertEquals($query->getStartDate(), $start);
-        $this->assertEquals($query->getEndDate(), $end);
+        $this->assertSame($query->getStartDate(), $start);
+        $this->assertSame($query->getEndDate(), $end);
     }
 
     public function testSetDatesFromSettersPeriod(): void
@@ -47,8 +47,8 @@ final class QueryByFiltersTest extends TestCase
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
         $this->assertSame($query, $query->setPeriod($start, $end), 'The setter should be fluid');
 
-        $this->assertEquals($query->getStartDate(), $start);
-        $this->assertEquals($query->getEndDate(), $end);
+        $this->assertSame($query->getStartDate(), $start);
+        $this->assertSame($query->getEndDate(), $end);
     }
 
     public function testSetDatesFromSetStartEndDate(): void
@@ -60,8 +60,8 @@ final class QueryByFiltersTest extends TestCase
         $this->assertSame($query, $query->setStartDate($start), 'The setter should be fluid');
         $this->assertSame($query, $query->setEndDate($end), 'The setter should be fluid');
 
-        $this->assertEquals($query->getStartDate(), $start);
-        $this->assertEquals($query->getEndDate(), $end);
+        $this->assertSame($query->getStartDate(), $start);
+        $this->assertSame($query->getEndDate(), $end);
     }
 
     public function testSetComplementOption(): void
@@ -86,7 +86,7 @@ final class QueryByFiltersTest extends TestCase
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
         $this->assertSame($query, $query->setRfc(new RfcOption($rfc)), 'The setter should be fluid');
 
-        $this->assertEquals($query->getRfc()->value(), $rfc);
+        $this->assertSame($rfc, $query->getRfc()->value());
     }
 
     public function testSetRfcOnBehalfOption(): void
@@ -95,6 +95,6 @@ final class QueryByFiltersTest extends TestCase
         $query = new Query(new DateTimeImmutable('2019-01-01'), new DateTimeImmutable('2019-01-31'));
         $this->assertSame($query, $query->setRfcOnBehalf(new RfcOnBehalfOption($rfc)), 'The setter should be fluid');
 
-        $this->assertEquals($query->getRfcOnBehalf()->value(), $rfc);
+        $this->assertSame($rfc, $query->getRfcOnBehalf()->value());
     }
 }

--- a/tests/Unit/SatHttpGatewayTest.php
+++ b/tests/Unit/SatHttpGatewayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace PhpCfdi\CfdiSatScraper\Tests\Unit;
 
 use PhpCfdi\CfdiSatScraper\SatHttpGateway;

--- a/tests/Unit/SatHttpGatewayTest.php
+++ b/tests/Unit/SatHttpGatewayTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit;
+
+use PhpCfdi\CfdiSatScraper\SatHttpGateway;
+use PHPUnit\Framework\TestCase;
+
+final class SatHttpGatewayTest extends TestCase
+{
+    public function testMethodPostLoginDataIsDeprecated(): void
+    {
+        $gateway = new SatHttpGateway();
+        $this->expectDeprecation();
+        $gateway->postLoginData('foo', []);
+    }
+}

--- a/tests/generate-repository.php
+++ b/tests/generate-repository.php
@@ -89,9 +89,9 @@ exit(call_user_func(new class () {
     public function printHelp(): void
     {
         echo "$this->command start-date end-date", PHP_EOL,
-            'start-date end-date are dates, time is ignored', PHP_EOL,
-            'This script is a helper to retrieve issued and received cfdi on specific dates,', PHP_EOL,
-            'the resulting json can be stored as a source of true to perform the integration tests.', PHP_EOL,
-            'The configuration options are the same as used on integration tests', PHP_EOL;
+        'start-date end-date are dates, time is ignored', PHP_EOL,
+        'This script is a helper to retrieve issued and received cfdi on specific dates,', PHP_EOL,
+        'the resulting json can be stored as a source of true to perform the integration tests.', PHP_EOL,
+        'The configuration options are the same as used on integration tests', PHP_EOL;
     }
 }, ...$argv));


### PR DESCRIPTION
Se admite la compatibilidad con Symfony 6. Esto evita que se tengan que degradar componentes a la versión 5.

Se depreca `SatHttpGatewayException::postLoginData` para crear el método específico
`SatHttpGatewayException::postCiecLoginData`. Esto no altera la funcionalidad actual.

Se agrega la dependencia faltante `mbstring`.

### Cambios en el entorno de desarrollo

Se mejoran los test para probar valores idénticos en lugar de valores iguales.

Se actualizan las herramientas de desarrollo.

Se actualiza el archivo de configuración de `php-cs-fixer`. 
