### PR TITLE
Corrección de Metadata::hasResource y CI.

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.9.3" installed="3.9.3" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.9.5" installed="3.9.5" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.8.1" installed="1.8.1" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.8.2" installed="1.8.2" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -17,8 +17,6 @@ return (new PhpCsFixer\Config())
         '@PSR12:risky' => true,
         '@PHP71Migration:risky' => true,
         '@PHP73Migration' => true,
-        // PHP73Migration
-        'method_argument_space' => ['on_multiline' => 'ignore'],
         // symfony
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/css-selector": "^5.4|^6.0",
         "eclipxe/enum": "^0.2.0",
-        "eclipxe/micro-catalog": "^0.1.2",
+        "eclipxe/micro-catalog": "^v0.1.3",
         "phpcfdi/credentials": "^1.1",
         "phpcfdi/image-captcha-resolver": "^0.2.0"
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,25 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 No hay cambios no liberados, si existen, deben aparecer aquí.
 
+## Versión 3.1.2
+
+### Filtrado de recursos incorrecto
+
+Problema: Si el objeto `Metadata` contenía la entrada del recurso, pero estaba vacía,
+entonces la función `hasResource` devolvía verdadero. Esto hacía que fallara el filtrado.
+Se corrigió el problema comparando contra el valor vacío y no contra la existencia de la llave.
+Gracias `@micotito` por la detección del problema.
+
+### Actualización de `eclipxe/micro-catalog`
+
+La nueva versión de `eclipxe/micro-catalog` necesita la especificación del tipo de datos
+para `MicroCatalog` en la clase `ComplementsOption`.
+
+### Actualización de herramientas de desarrollo
+
+- Se actualizan las herramientas.
+- Se elimina la regla `method_argument_space` para dejar la definición por defecto de PSR-12.
+
 ## Versión 3.1.1
 
 ### Cambios en el código

--- a/src/Filters/Options/ComplementsOption.php
+++ b/src/Filters/Options/ComplementsOption.php
@@ -101,6 +101,8 @@ use PhpCfdi\CfdiSatScraper\Exceptions\InvalidArgumentException;
  *
  * @method string getInput()
  * @method string getDescription()
+ *
+ * @extends MicroCatalog<array{input: string, description: string}>
  */
 class ComplementsOption extends MicroCatalog implements FilterOption
 {
@@ -294,7 +296,7 @@ class ComplementsOption extends MicroCatalog implements FilterOption
         return self::VALUES;
     }
 
-    public function getEntryValueOnUndefined(): void
+    public function getEntryValueOnUndefined(): array
     {
         throw InvalidArgumentException::complementsOptionInvalidKey((string) $this->getEntryIndex());
     }

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -108,7 +108,7 @@ class Metadata implements JsonSerializable, IteratorAggregate
 
     public function hasResource(ResourceType $resourceType): bool
     {
-        return $this->has($resourceType->value());
+        return '' !== $this->get($resourceType->value());
     }
 
     /** @return Traversable<string, string> */

--- a/tests/Unit/MetadataListTest.php
+++ b/tests/Unit/MetadataListTest.php
@@ -133,14 +133,14 @@ final class MetadataListTest extends TestCase
     public function testFilterWithResourceLink(): void
     {
         $faker = $this->fakes()->faker();
-        $withXmlUrl = $this->createMetadataArrayUsingUuids(...[ // 3 items
-            $faker->uuid,
-            $faker->uuid,
-            $faker->uuid,
-        ]);
+        $withXmlUrl = $this->createMetadataArrayUsingUuids( // 3 items
+            $faker->uuid(),
+            $faker->uuid(),
+            $faker->uuid(),
+        );
         $metadatas = $withXmlUrl + [  // + 2 items without url
-            $uuid = $faker->uuid => new Metadata($uuid),
-            $uuid = $faker->uuid => new Metadata($uuid),
+            $uuid = $faker->uuid() => new Metadata($uuid, [ResourceType::xml()->value() => '']), // url is empty
+            $uuid = $faker->uuid() => new Metadata($uuid), // url is not defined
         ];
         shuffle($metadatas);
         $metadataList = new MetadataList($metadatas);

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -108,4 +108,20 @@ final class MetadataTest extends TestCase
         $this->assertInstanceOf(Traversable::class, $metadata);
         $this->assertSame($data, iterator_to_array($metadata));
     }
+
+    public function testHasResource(): void
+    {
+        $uuid = $this->fakes()->faker()->uuid();
+        $data = ['uuid' => $uuid];
+        foreach (ResourceType::toArray() as $value) {
+            $data[$value] = '';
+        }
+
+        $metadata = new Metadata($uuid, $data);
+
+        foreach (ResourceType::toArray() as $value) {
+            $resourceType = new ResourceType($value);
+            $this->assertFalse($metadata->hasResource($resourceType));
+        }
+    }
 }


### PR DESCRIPTION
- Se corrige `Metadata::hasResource` para que filtre correctamente cuando no existen recursos.
- Se corrige el flujo de integración continua.