### PR TITLE
Actualización en el MetadataExtractor

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 No hay cambios no liberados, si existen, deben aparecer aquí.
 
+## Versión 3.2.0
+
+### Agregar *Motivo de cancelación* y *Folio de sustitución*
+
+Se agrega la lectura de *Motivo de cancelación* (`motivoCancelacion`) y *Folio de sustitución* (`folioSustitucion`) a `Metadata`. Así como la extracción de estos datos en `MetadataExtractor`.
+Gracias `@TheSpectroMx`.
+
 ## Versión 3.1.2
 
 ### Filtrado de recursos incorrecto

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -82,8 +82,8 @@ class MetadataExtractor
             'estatusProcesoCancelacion' => 'Estatus de Proceso de Cancelación',
             'fechaProcesoCancelacion' => 'Fecha de Proceso de Cancelación',
             'rfcACuentaTerceros' => 'RFC a cuenta de terceros',
-            'Motivo' => 'Motivo',
-            'folioDeSustitucion' => 'Folio de Sustitución',
+            'motivo' => 'Motivo',
+            'folioSustitucion' => 'Folio de Sustitución',
         ];
     }
 

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -82,7 +82,7 @@ class MetadataExtractor
             'estatusProcesoCancelacion' => 'Estatus de Proceso de Cancelación',
             'fechaProcesoCancelacion' => 'Fecha de Proceso de Cancelación',
             'rfcACuentaTerceros' => 'RFC a cuenta de terceros',
-            'motivo' => 'Motivo',
+            'motivoCancelacion' => 'Motivo',
             'folioSustitucion' => 'Folio de Sustitución',
         ];
     }

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -82,6 +82,8 @@ class MetadataExtractor
             'estatusProcesoCancelacion' => 'Estatus de Proceso de Cancelación',
             'fechaProcesoCancelacion' => 'Fecha de Proceso de Cancelación',
             'rfcACuentaTerceros' => 'RFC a cuenta de terceros',
+            'Motivo' => 'Motivo',
+            'folioDeSustitucion' => 'Folio de Sustitución',
         ];
     }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -33,6 +33,8 @@ use Traversable;
  * @property-read string $estatusProcesoCancelacion Estatus de Proceso de Cancelación
  * @property-read string $fechaProcesoCancelacion Fecha de Proceso de Cancelación
  * @property-read string $rfcACuentaTerceros RFC a cuenta de terceros
+ * @property-read string $motivoCancelacion Motivo de cancelación
+ * @property-read string $folioSustitucion UUID del CFDI con el que es sustituido
  *
  * @see MetadataExtractor::defaultFieldsCaptions()
  * @implements IteratorAggregate<string, string>

--- a/tests/Unit/Internal/MetadataExtractorTest.php
+++ b/tests/Unit/Internal/MetadataExtractorTest.php
@@ -183,6 +183,8 @@ final class MetadataExtractorTest extends TestCase
             'estatusProcesoCancelacion' => '',
             'fechaProcesoCancelacion' => '',
             'rfcACuentaTerceros' => 'AAA991231AAA',
+            'motivo' => '',
+            'folioSustitucion' => '',
             'urlXml' => '', // the data is not included on test file
             'urlPdf' => '',
             'urlCancelRequest' => '',
@@ -220,6 +222,8 @@ final class MetadataExtractorTest extends TestCase
                 'estatusProcesoCancelacion' => '',
                 'fechaProcesoCancelacion' => '',
                 'rfcACuentaTerceros' => 'ABC010101AAA',
+                'motivo' => '',
+                'folioSustitucion' => '',
             ],
         ];
 

--- a/tests/Unit/Internal/MetadataExtractorTest.php
+++ b/tests/Unit/Internal/MetadataExtractorTest.php
@@ -183,7 +183,7 @@ final class MetadataExtractorTest extends TestCase
             'estatusProcesoCancelacion' => '',
             'fechaProcesoCancelacion' => '',
             'rfcACuentaTerceros' => 'AAA991231AAA',
-            'motivo' => '',
+            'motivoCancelacion' => '',
             'folioSustitucion' => '',
             'urlXml' => '', // the data is not included on test file
             'urlPdf' => '',
@@ -222,7 +222,7 @@ final class MetadataExtractorTest extends TestCase
                 'estatusProcesoCancelacion' => '',
                 'fechaProcesoCancelacion' => '',
                 'rfcACuentaTerceros' => 'ABC010101AAA',
-                'motivo' => '',
+                'motivoCancelacion' => '',
                 'folioSustitucion' => '',
             ],
         ];

--- a/tests/_files/fake-to-extract-metadata-missing-uuid.html
+++ b/tests/_files/fake-to-extract-metadata-missing-uuid.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -35,6 +37,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -54,6 +58,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -71,6 +77,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>

--- a/tests/_files/fake-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-one-cfdi.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -36,6 +38,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">AAA991231AAA</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>
     </body>

--- a/tests/_files/fake-to-extract-metadata-ten-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-ten-cfdi.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -35,6 +37,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -54,6 +58,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -71,6 +77,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -90,6 +98,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -107,6 +117,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -126,6 +138,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -144,6 +158,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -161,6 +177,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -179,6 +197,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -196,6 +216,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>

--- a/tests/_files/fake-to-extract-metadata-zero-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-zero-cfdi.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
         </table>
     </body>

--- a/tests/_files/sample-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/sample-to-extract-metadata-one-cfdi.html
@@ -758,6 +758,12 @@
 			<th>
                                         <span style="width: 200px;">RFC a cuenta de terceros</span>
                                     </th>
+			<th>
+                                        <span style="width: 200px;">Motivo</span>
+                                    </th>
+			<th>
+                                        <span style="width: 200px;">Folio de Sustitución</span>
+                                    </th>
 		</tr>
 		<tr>
 			<td><div style="width:150px; display:block;text-align:center;vertical-align:middle; position: relative;"><table>
@@ -790,6 +796,8 @@
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
             <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;">ABC010101AAA</span></td>
+			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
         </tr>
         <tr>
             <td>


### PR DESCRIPTION
Se modifica la función `defaultFieldsCaptions()` ya que el SAT añadió dos columnas más (Motivo y Folio de Sustitución) para que posiblemente quede de la siguiente manera:
```php
    public function defaultFieldsCaptions(): array
    {
        return [
            'uuid' => 'Folio Fiscal',
            'rfcEmisor' => 'RFC Emisor',
            'nombreEmisor' => 'Nombre o Razón Social del Emisor',
            'rfcReceptor' => 'RFC Receptor',
            'nombreReceptor' => 'Nombre o Razón Social del Receptor',
            'fechaEmision' => 'Fecha de Emisión',
            'fechaCertificacion' => 'Fecha de Certificación',
            'pacCertifico' => 'PAC que Certificó',
            'total' => 'Total',
            'efectoComprobante' => 'Efecto del Comprobante',
            'estatusCancelacion' => 'Estatus de cancelación',
            'estadoComprobante' => 'Estado del Comprobante',
            'estatusProcesoCancelacion' => 'Estatus de Proceso de Cancelación',
            'fechaProcesoCancelacion' => 'Fecha de Proceso de Cancelación',
            'rfcACuentaTerceros' => 'RFC a cuenta de terceros',
            'motivoCancelacion' => 'Motivo',
            'folioSustitucion' => 'Folio de Sustitución',
        ];
    }
```
Gracias de antemano