### PR TITLE
Corrección de construcción de integración continua

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.9.5" installed="3.9.5" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.10.0" installed="3.10.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^1.8.2" installed="1.8.2" location="./tools/phpstan" copy="false"/>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,11 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
-No hay cambios no liberados, si existen, deben aparecer aquí.
+### 2022-10-22: Corrección de construcción de integración continua
+
+- Se actualizaron las herramientas de desarrollo.
+- Se aplicó la corrección de `php-cs-fixer`.
+- Se corrigió el nombre de usuario de `@git-micotito` en este mismo archivo.
 
 ## Versión 3.2.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,7 +22,7 @@ Gracias `@TheSpectroMx`.
 Problema: Si el objeto `Metadata` contenía la entrada del recurso, pero estaba vacía,
 entonces la función `hasResource` devolvía verdadero. Esto hacía que fallara el filtrado.
 Se corrigió el problema comparando contra el valor vacío y no contra la existencia de la llave.
-Gracias `@micotito` por la detección del problema.
+Gracias `@git-micotito` por la detección del problema.
 
 ### Actualización de `eclipxe/micro-catalog`
 

--- a/tests/Unit/SatScraperDownloadMethodsTest.php
+++ b/tests/Unit/SatScraperDownloadMethodsTest.php
@@ -71,7 +71,6 @@ final class SatScraperDownloadMethodsTest extends TestCase
 
     public function testListByPeriodCallDownloaderMethod(): void
     {
-
         /** @var SatScraper&MockObject $scraper */
         $scraper = $this->getMockBuilder(SatScraper::class)
             ->disableOriginalConstructor()


### PR DESCRIPTION
- Se actualizaron las herramientas de desarrollo.
- Se aplicó la corrección de `php-cs-fixer`.
- Se corrigió el nombre de usuario de `@git-micotito` en este mismo archivo.
