### PR TITLE
Corrección del proceso de integración continua y mantenimiento

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.10.0" installed="3.10.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.13.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.8.2" installed="1.8.2" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.9.1" installed="1.9.1" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -28,7 +28,7 @@ return (new PhpCsFixer\Config())
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 ### 2022-11-09: Corrección de construcción de integración continua
 
 - Se actualizaron las herramientas de desarrollo.
+- Se agrega PHP 8.2 a la matriz de pruebas en el proceso de integración continua.
 - Se corrige la firma (`phpdoc`) del método `HttpLogger::bodyToVars`.
 - Se corrige el método `Repository::randomize` pues perdía las llaves del arreglo.
 - Se corrige el archivo de configuración de `php-cs-fixer` porque la regla `no_trailing_comma_in_singleline_array` está deprecada.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
+### 2022-11-09: Corrección de construcción de integración continua
+
+- Se actualizaron las herramientas de desarrollo.
+- Se corrige la firma (`phpdoc`) del método `HttpLogger::bodyToVars`.
+- Se corrige el método `Repository::randomize` pues perdía las llaves del arreglo.
+- Se corrige el archivo de configuración de `php-cs-fixer` porque la regla `no_trailing_comma_in_singleline_array` está deprecada.
+
 ### 2022-10-22: Corrección de construcción de integración continua
 
 - Se actualizaron las herramientas de desarrollo.

--- a/tests/Integration/HttpLogger.php
+++ b/tests/Integration/HttpLogger.php
@@ -110,7 +110,7 @@ class HttpLogger extends ArrayObject
 
     /**
      * @param string $body
-     * @return array<string, string[]>
+     * @return array<string|array<string>>
      */
     public function bodyToVars(string $body): array
     {

--- a/tests/Integration/Repository.php
+++ b/tests/Integration/Repository.php
@@ -95,7 +95,11 @@ class Repository implements Countable, IteratorAggregate, JsonSerializable
     {
         $items = $this->items;
         shuffle($items);
-        return new self($items);
+        $itemsWithUuid = [];
+        foreach ($items as $item) {
+            $itemsWithUuid[$item->getUuid()] = $item;
+        }
+        return new self($itemsWithUuid);
     }
 
     public function topItems(int $length): self


### PR DESCRIPTION
- Se actualizaron las herramientas de desarrollo.
- Se corrige la firma (`phpdoc`) del método `HttpLogger::bodyToVars`.
- Se corrige el método `Repository::randomize` pues perdía las llaves del arreglo.
- Se corrige el archivo de configuración de `php-cs-fixer` porque la regla `no_trailing_comma_in_singleline_array` está deprecada.
