### PR TITLE
Quitar "Motivo de cancelación" y "Folio de sustitución" (Version 3.2.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -93,7 +93,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,7 +25,7 @@ jobs:
           fail-fast: true
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:
@@ -53,15 +53,15 @@ jobs:
         id: check-secrets
         run: |
           if [ -n "${{ secrets.GITHUB_TOKEN }}" ]; then
-            echo "::set-output name=github::yes"
+            echo "github=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=github::no"
+            echo "github=no" >> $GITHUB_OUTPUT
             echo "::warning ::GITHUB_TOKEN non set"
           fi
           if [ -n "${{ secrets.SONAR_TOKEN }}" ]; then
-            echo "::set-output name=sonar::yes"
+            echo "sonar=yes" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=sonar::no"
+            echo "sonar=no" >> $GITHUB_OUTPUT
             echo "::warning ::SONAR_TOKEN non set"
           fi
 
@@ -83,7 +83,7 @@ jobs:
           tools: composer:v2
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
         uses: actions/cache@v3
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2022 PhpCfdi https://www.phpcfdi.com
+Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/packagist/php-v/phpcfdi/cfdi-sat-scraper?logo=php
 [badge-release]: https://img.shields.io/github/release/phpcfdi/cfdi-sat-scraper?logo=git
 [badge-license]: https://img.shields.io/github/license/phpcfdi/cfdi-sat-scraper?logo=open-source-initiative
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/cfdi-sat-scraper/build/main?logo=github-actions
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/cfdi-sat-scraper/build.yml?branch=main&logo=github-actions
 [badge-reliability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_cfdi-sat-scraper&metric=reliability_rating
 [badge-maintainability]: https://sonarcloud.io/api/project_badges/measure?project=phpcfdi_cfdi-sat-scraper&metric=sqale_rating
 [badge-coverage]: https://img.shields.io/sonar/coverage/phpcfdi_cfdi-sat-scraper/main?logo=sonarcloud&server=https%3A%2F%2Fsonarcloud.io

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,24 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
-### 2022-11-09: Corrección de construcción de integración continua
+No hay cambios aún no liberados actualmente.
+
+## Versión 3.2.1
+
+### Quitar *Motivo de cancelación* y *Folio de sustitución*
+
+Se elimina la lectura de *Motivo de cancelación* (`motivoCancelacion`) y *Folio de sustitución* (`folioSustitucion`).
+Aparentemente, en la fecha 2023-01-04 el SAT ha eliminado estas columnas.
+
+### Otros cambios menores
+
+- Actualización de licencia a 2023. ¡Feliz año!.
+- Actualización de flujos de trabajo sustituyendo la directiva `::set-output` con `$GITHUB_OUTPUT`.
+- Corrección de la insignia del flujo de construcción `build`.
+
+### Cambios previos
+
+#### 2022-11-09: Corrección de construcción de integración continua
 
 - Se actualizaron las herramientas de desarrollo.
 - Se agrega PHP 8.2 a la matriz de pruebas en el proceso de integración continua.
@@ -14,7 +31,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 - Se corrige el método `Repository::randomize` pues perdía las llaves del arreglo.
 - Se corrige el archivo de configuración de `php-cs-fixer` porque la regla `no_trailing_comma_in_singleline_array` está deprecada.
 
-### 2022-10-22: Corrección de construcción de integración continua
+#### 2022-10-22: Corrección de construcción de integración continua
 
 - Se actualizaron las herramientas de desarrollo.
 - Se aplicó la corrección de `php-cs-fixer`.

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -82,8 +82,6 @@ class MetadataExtractor
             'estatusProcesoCancelacion' => 'Estatus de Proceso de Cancelación',
             'fechaProcesoCancelacion' => 'Fecha de Proceso de Cancelación',
             'rfcACuentaTerceros' => 'RFC a cuenta de terceros',
-            'motivoCancelacion' => 'Motivo',
-            'folioSustitucion' => 'Folio de Sustitución',
         ];
     }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -33,8 +33,6 @@ use Traversable;
  * @property-read string $estatusProcesoCancelacion Estatus de Proceso de Cancelación
  * @property-read string $fechaProcesoCancelacion Fecha de Proceso de Cancelación
  * @property-read string $rfcACuentaTerceros RFC a cuenta de terceros
- * @property-read string $motivoCancelacion Motivo de cancelación
- * @property-read string $folioSustitucion UUID del CFDI con el que es sustituido
  *
  * @see MetadataExtractor::defaultFieldsCaptions()
  * @implements IteratorAggregate<string, string>

--- a/tests/Unit/Internal/MetadataExtractorTest.php
+++ b/tests/Unit/Internal/MetadataExtractorTest.php
@@ -183,8 +183,6 @@ final class MetadataExtractorTest extends TestCase
             'estatusProcesoCancelacion' => '',
             'fechaProcesoCancelacion' => '',
             'rfcACuentaTerceros' => 'AAA991231AAA',
-            'motivoCancelacion' => '',
-            'folioSustitucion' => '',
             'urlXml' => '', // the data is not included on test file
             'urlPdf' => '',
             'urlCancelRequest' => '',
@@ -222,8 +220,6 @@ final class MetadataExtractorTest extends TestCase
                 'estatusProcesoCancelacion' => '',
                 'fechaProcesoCancelacion' => '',
                 'rfcACuentaTerceros' => 'ABC010101AAA',
-                'motivoCancelacion' => '',
-                'folioSustitucion' => '',
             ],
         ];
 

--- a/tests/_files/fake-to-extract-metadata-missing-uuid.html
+++ b/tests/_files/fake-to-extract-metadata-missing-uuid.html
@@ -18,8 +18,6 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
-                <th><span>Motivo</span></th>
-                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -37,8 +35,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -58,8 +54,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -77,8 +71,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>

--- a/tests/_files/fake-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-one-cfdi.html
@@ -18,8 +18,6 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
-                <th><span>Motivo</span></th>
-                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -38,8 +36,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">AAA991231AAA</span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>
     </body>

--- a/tests/_files/fake-to-extract-metadata-ten-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-ten-cfdi.html
@@ -18,8 +18,6 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
-                <th><span>Motivo</span></th>
-                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -37,8 +35,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -58,8 +54,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -77,8 +71,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -118,8 +110,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -137,8 +127,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -158,8 +146,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -177,7 +163,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -197,8 +182,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -216,8 +199,6 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>

--- a/tests/_files/fake-to-extract-metadata-zero-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-zero-cfdi.html
@@ -18,8 +18,6 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
-                <th><span>Motivo</span></th>
-                <th><span>Folio de Sustitución</span></th>
             </tr>
         </table>
     </body>

--- a/tests/_files/sample-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/sample-to-extract-metadata-one-cfdi.html
@@ -758,12 +758,6 @@
 			<th>
                                         <span style="width: 200px;">RFC a cuenta de terceros</span>
                                     </th>
-			<th>
-                                        <span style="width: 200px;">Motivo</span>
-                                    </th>
-			<th>
-                                        <span style="width: 200px;">Folio de Sustitución</span>
-                                    </th>
 		</tr>
 		<tr>
 			<td><div style="width:150px; display:block;text-align:center;vertical-align:middle; position: relative;"><table>
@@ -796,8 +790,6 @@
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
             <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;">ABC010101AAA</span></td>
-			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
-			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
         </tr>
         <tr>
             <td>


### PR DESCRIPTION
Se elimina la lectura de *Motivo de cancelación* (`motivoCancelacion`) y *Folio de sustitución* (`folioSustitucion`). Aparentemente, en la fecha 2023-01-04 el SAT ha eliminado estas columnas.

### Otros cambios menores

- Actualización de licencia a 2023. ¡Feliz año!.
- Actualización de flujos de trabajo sustituyendo la directiva `::set-output` con `$GITHUB_OUTPUT`.
- Corrección de la insignia del flujo de construcción `build`.
