### PR TITLE
Agregar "Motivo de cancelación" y "Folio de sustitución" (Version 3.2.2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -38,13 +38,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: y
 
   phpstan:
     name: Code analysis (phpstan)
@@ -55,7 +57,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2, phpstan
         env:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.13.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.13.2" installed="3.13.2" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.9.1" installed="1.9.1" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.9.11" installed="1.9.11" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com
+Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,13 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 No hay cambios aún no liberados actualmente.
 
+## Versión 3.2.2
+
+### Regresar *Motivo de cancelación* y *Folio de sustitución*
+
+Se regresa la lectura de *Motivo de cancelación* (`motivoCancelacion`) y *Folio de sustitución* (`folioSustitucion`).
+Aparentemente, en la fecha 2023-01-12 el SAT ha regresado estas columnas.
+
 ## Versión 3.2.1
 
 ### Quitar *Motivo de cancelación* y *Folio de sustitución*

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -82,6 +82,8 @@ class MetadataExtractor
             'estatusProcesoCancelacion' => 'Estatus de Proceso de Cancelación',
             'fechaProcesoCancelacion' => 'Fecha de Proceso de Cancelación',
             'rfcACuentaTerceros' => 'RFC a cuenta de terceros',
+            'motivoCancelacion' => 'Motivo',
+            'folioSustitucion' => 'Folio de Sustitución',
         ];
     }
 

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -33,6 +33,8 @@ use Traversable;
  * @property-read string $estatusProcesoCancelacion Estatus de Proceso de Cancelación
  * @property-read string $fechaProcesoCancelacion Fecha de Proceso de Cancelación
  * @property-read string $rfcACuentaTerceros RFC a cuenta de terceros
+ * @property-read string $motivoCancelacion Motivo de cancelación
+ * @property-read string $folioSustitucion UUID del CFDI con el que es sustituido
  *
  * @see MetadataExtractor::defaultFieldsCaptions()
  * @implements IteratorAggregate<string, string>

--- a/tests/Unit/Internal/MetadataExtractorTest.php
+++ b/tests/Unit/Internal/MetadataExtractorTest.php
@@ -183,6 +183,8 @@ final class MetadataExtractorTest extends TestCase
             'estatusProcesoCancelacion' => '',
             'fechaProcesoCancelacion' => '',
             'rfcACuentaTerceros' => 'AAA991231AAA',
+            'motivoCancelacion' => '',
+            'folioSustitucion' => '',
             'urlXml' => '', // the data is not included on test file
             'urlPdf' => '',
             'urlCancelRequest' => '',
@@ -220,6 +222,8 @@ final class MetadataExtractorTest extends TestCase
                 'estatusProcesoCancelacion' => '',
                 'fechaProcesoCancelacion' => '',
                 'rfcACuentaTerceros' => 'ABC010101AAA',
+                'motivoCancelacion' => '',
+                'folioSustitucion' => '',
             ],
         ];
 

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -96,7 +96,7 @@ final class MetadataTest extends TestCase
     {
         $metadata = new Metadata($this->fakes()->faker()->uuid, []);
         $this->expectException(LogicException::class);
-        unset($metadata->{'foo'});
+        unset($metadata->{'foo'}); /** @phpstan-ignore-line */
     }
 
     public function testIterateOverData(): void

--- a/tests/_files/fake-to-extract-metadata-missing-uuid.html
+++ b/tests/_files/fake-to-extract-metadata-missing-uuid.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -35,6 +37,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -54,6 +58,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -71,6 +77,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>

--- a/tests/_files/fake-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-one-cfdi.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -36,6 +38,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">AAA991231AAA</span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>
     </body>

--- a/tests/_files/fake-to-extract-metadata-ten-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-ten-cfdi.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -35,6 +37,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -54,6 +58,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -71,6 +77,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -110,6 +118,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -127,6 +137,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -146,6 +158,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -163,6 +177,7 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
@@ -182,6 +197,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
             <tr>
                 <td style="width:14.2%;">...</td>
@@ -199,6 +216,8 @@
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;">Vigente</span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+                <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
                 <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
             </tr>
         </table>

--- a/tests/_files/fake-to-extract-metadata-zero-cfdi.html
+++ b/tests/_files/fake-to-extract-metadata-zero-cfdi.html
@@ -18,6 +18,8 @@
                 <th><span>Estatus de Proceso de Cancelación</span></th>
                 <th><span>Fecha de Proceso de Cancelación</span></th>
                 <th><span>RFC a cuenta de terceros</span></th>
+                <th><span>Motivo</span></th>
+                <th><span>Folio de Sustitución</span></th>
             </tr>
         </table>
     </body>

--- a/tests/_files/sample-to-extract-metadata-one-cfdi.html
+++ b/tests/_files/sample-to-extract-metadata-one-cfdi.html
@@ -758,6 +758,12 @@
 			<th>
                                         <span style="width: 200px;">RFC a cuenta de terceros</span>
                                     </th>
+			<th>
+                                        <span style="width: 200px;">Motivo</span>
+                                    </th>
+			<th>
+                                        <span style="width: 200px;">Folio de Sustitución</span>
+                                    </th>
 		</tr>
 		<tr>
 			<td><div style="width:150px; display:block;text-align:center;vertical-align:middle; position: relative;"><table>
@@ -790,6 +796,8 @@
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
 			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:200px;"> </span></td>
             <td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;">ABC010101AAA</span></td>
+			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
+			<td style="WORD-BREAK:BREAK-ALL;"><span style="display:inline-block;width:240px;"></span></td>
         </tr>
         <tr>
             <td>


### PR DESCRIPTION
Se agrega la lectura de *Motivo de cancelación* (`motivoCancelacion`) y *Folio de sustitución* (`folioSustitucion`). Aparentemente, en la fecha 2023-01-12 el SAT ha agregado estas columnas.
Previamente las había eliminado pero parece que se arrepintió.