### PR TITLE
Mantenimiento 2023-01-31

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.13.2" installed="3.13.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.3" installed="3.14.3" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.9.11" installed="1.9.11" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.9.14" installed="1.9.14" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,11 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
-No hay cambios aún no liberados actualmente.
+### Cambios no liberados: 2023-01-31
+
+- Actualización de herramientas de desarrollo.
+- En las pruebas, se elimina una anotación para PHPStan para ignorar un error al realizar `unset` sobre una
+  variable indefinida en un objeto de tipo `Metadata`.
 
 ## Versión 3.2.2
 

--- a/tests/Unit/MetadataTest.php
+++ b/tests/Unit/MetadataTest.php
@@ -96,7 +96,7 @@ final class MetadataTest extends TestCase
     {
         $metadata = new Metadata($this->fakes()->faker()->uuid, []);
         $this->expectException(LogicException::class);
-        unset($metadata->{'foo'}); /** @phpstan-ignore-line */
+        unset($metadata->{'foo'});
     }
 
     public function testIterateOverData(): void


### PR DESCRIPTION
- En las pruebas, se elimina una anotación para PHPStan para ignorar un error al realizar `unset` sobre una variable indefinida en un objeto de tipo `Metadata`.
- Actualización de herramientas de desarrollo.