### PR TITLE
Mantenimiento 20230213 (fix build)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.14.3" installed="3.14.3" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.4" installed="3.14.4" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.9.14" installed="1.9.14" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.9.17" installed="1.9.17" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         }
     ],
     "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        },
         "preferred-install": {
             "*": "dist"
         },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
+### Cambios no liberados: 2023-02-13
+
+- Actualización de herramientas de desarrollo.
+- Se agrega la configuración en `composer.json` para no permitir el uso de *plugins* de `php-http/discovery`.
+- En las pruebas, se refactoriza `SatHttpGatewayTest::testMethodPostLoginDataIsDeprecated` para probar que
+  el método `postLoginData` está deprecado, dado que PHPUnit 9.6 descontinuó el método `expectDeprecation`.
+
 ### Cambios no liberados: 2023-01-31
 
 - Actualización de herramientas de desarrollo.

--- a/tests/Unit/SatHttpGatewayTest.php
+++ b/tests/Unit/SatHttpGatewayTest.php
@@ -11,8 +11,15 @@ final class SatHttpGatewayTest extends TestCase
 {
     public function testMethodPostLoginDataIsDeprecated(): void
     {
-        $gateway = new SatHttpGateway();
-        $this->expectDeprecation();
-        $gateway->postLoginData('foo', []);
+        $gateway = new class () extends SatHttpGateway {
+            public function postCiecLoginData(string $loginUrl, array $formParams): string
+            {
+                return '';
+            }
+        };
+
+        @$gateway->postLoginData('foo', []);
+        $error = error_get_last() ?? [];
+        $this->assertSame(E_USER_DEPRECATED, intval($error['type'] ?? 0));
     }
 }


### PR DESCRIPTION
Este PR corrige el workflow de construcción, no contiene cambios en el código por lo que no se necesita liberar una nueva versión.

- Actualización de herramientas de desarrollo.
- Se agrega la configuración en `composer.json` para no permitir el uso de *plugins* de `php-http/discovery`.
- En las pruebas, se refactoriza `SatHttpGatewayTest::testMethodPostLoginDataIsDeprecated` para probar que el método `postLoginData` está deprecado, dado que PHPUnit 9.6 descontinuó el método `expectDeprecation`.
