### PR TITLE
Mantenimiento 2023-05-25 (corrige integración continua)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.14.4" installed="3.14.4" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.9.17" installed="1.9.17" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.17.0" installed="3.17.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.15" installed="1.10.15" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -63,11 +63,11 @@
             "@dev:tests"
         ],
         "dev:check-style": [
-            "@php tools/php-cs-fixer fix --dry-run --verbose",
+            "@php -r 'exit(intval(PHP_VERSION_ID >= 74000));' || $PHP_BINARY tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
-            "@php tools/php-cs-fixer fix --verbose",
+            "@php -r 'exit(intval(PHP_VERSION_ID >= 74000));' || $PHP_BINARY tools/php-cs-fixer fix --verbose",
             "@php tools/phpcbf --colors -sp"
         ],
         "dev:tests": [

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ext-fileinfo": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.1|^2.0",
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/promises": "^2.0",
         "symfony/dom-crawler": "^5.4|^6.0",
@@ -49,7 +49,7 @@
         "eclipxe/enum": "^0.2.0",
         "eclipxe/micro-catalog": "^v0.1.3",
         "phpcfdi/credentials": "^1.1",
-        "phpcfdi/image-captcha-resolver": "^0.2.0"
+        "phpcfdi/image-captcha-resolver": "^0.2.3"
     },
     "require-dev": {
         "ext-iconv": "*",

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ext-openssl": "*",
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": "^7.0",
-        "guzzlehttp/promises": "^1.3",
+        "guzzlehttp/promises": "^2.0",
         "symfony/dom-crawler": "^5.4|^6.0",
         "symfony/css-selector": "^5.4|^6.0",
         "eclipxe/enum": "^0.2.0",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Estos cambios se realizan en el entorno de desarrollo y pruebas, por lo que no e
 
 - Se refactoriza la clase `RepositoryItem` para que las responsabilidades de la creación de una instancia 
   a partir de un arreglo se realizen en la clase `RepositoryItemFactory`.
+- Se corrige el issue falso positivo encontrado por PHPStan al convertir un objeto a cadena de caracteres.
 
 ### Cambios no liberados: 2023-02-13
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,12 +10,15 @@ En este momento no hay cambios no liberados.
 
 ## Versión 3.2.3 2023-05-25
 
-- Se actualiza la dependencia de `guzzlehttp/promises` a versión 2.0.
+- Se actualiza la dependencia de `guzzlehttp/promises` a versión mínima 2.0.
+- Se actualiza la dependencia de `psr/http-message` a versiones mínimas 1.1 o 2.0.
+- Se actualiza la dependencia de `phpcfdi/image-captcha-resolver` a versión mínima 0.2.3.
 
 Los siguientes cambios aplican al entorno de desarrollo:
 
 - Se refactoriza la clase `RepositoryItem` para que las responsabilidades de la creación de una instancia 
   a partir de un arreglo se realizen en la clase `RepositoryItemFactory`.
+- Se corrigen las pruebas para usar `psr/http-message:^2.0`.
 - Se corrige el issue falso positivo encontrado por PHPStan al convertir un objeto a cadena de caracteres.
 - Actualización de herramientas de desarrollo.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
+### Cambios no liberados: 2023-05-25
+
+Estos cambios se realizan en el entorno de desarrollo y pruebas, por lo que no es necesario hacer una liberación.
+
+- Se refactoriza la clase `RepositoryItem` para que las responsabilidades de la creación de una instancia 
+  a partir de un arreglo se realizen en la clase `RepositoryItemFactory`.
+
 ### Cambios no liberados: 2023-02-13
 
 - Actualización de herramientas de desarrollo.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ En este momento no hay cambios no liberados.
 
 Los siguientes cambios aplican al entorno de desarrollo:
 
+- La ejecución de `php-cs-fixer` dentro de `composer` se condiciona a mínimo PHP 8.0.
 - Se refactoriza la clase `RepositoryItem` para que las responsabilidades de la creación de una instancia 
   a partir de un arreglo se realizen en la clase `RepositoryItemFactory`.
 - Se corrigen las pruebas para usar `psr/http-message:^2.0`.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Estos cambios se realizan en el entorno de desarrollo y pruebas, por lo que no e
 - Se refactoriza la clase `RepositoryItem` para que las responsabilidades de la creación de una instancia 
   a partir de un arreglo se realizen en la clase `RepositoryItemFactory`.
 - Se corrige el issue falso positivo encontrado por PHPStan al convertir un objeto a cadena de caracteres.
+- Actualización de herramientas de desarrollo.
 
 ### Cambios no liberados: 2023-02-13
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,14 +6,20 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
-### Cambios no liberados: 2023-05-25
+En este momento no hay cambios no liberados.
 
-Estos cambios se realizan en el entorno de desarrollo y pruebas, por lo que no es necesario hacer una liberación.
+## Versión 3.2.3 2023-05-25
+
+- Se actualiza la dependencia de `guzzlehttp/promises` a versión 2.0.
+
+Los siguientes cambios aplican al entorno de desarrollo:
 
 - Se refactoriza la clase `RepositoryItem` para que las responsabilidades de la creación de una instancia 
   a partir de un arreglo se realizen en la clase `RepositoryItemFactory`.
 - Se corrige el issue falso positivo encontrado por PHPStan al convertir un objeto a cadena de caracteres.
 - Actualización de herramientas de desarrollo.
+
+También se concluyen los siguientes cambios previos no liberados.
 
 ### Cambios no liberados: 2023-02-13
 

--- a/src/Exceptions/ResourceDownloadError.php
+++ b/src/Exceptions/ResourceDownloadError.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\CfdiSatScraper\Exceptions;
 
+use Stringable;
 use Throwable;
 
 /**
@@ -67,6 +68,11 @@ class ResourceDownloadError extends \RuntimeException implements SatException
             return strval($reason);
         }
         if (is_object($reason) && is_callable([$reason, '__toString'])) {
+            /**
+             * Fix PHPStan false positive detecting cast from object to string
+             * @phpstan-var Stringable $reason
+             * @noinspection PhpMultipleClassDeclarationsInspection
+             */
             return strval($reason);
         }
         return print_r($reason, true);

--- a/src/ResourceDownloader.php
+++ b/src/ResourceDownloader.php
@@ -210,7 +210,7 @@ class ResourceDownloader
      * @throws RuntimeException if ask to create folder path exists and is not a folder
      * @throws RuntimeException if unable to create folder
      *
-     * @see \PhpCfdi\CfdiSatScraper\Internal\ResourceDownloadStoreInFolder
+     * @see ResourceDownloadStoreInFolder
      */
     public function saveTo(string $destinationFolder, bool $createFolder = false, int $createMode = 0775): array
     {

--- a/tests/Integration/Repository.php
+++ b/tests/Integration/Repository.php
@@ -50,12 +50,14 @@ class Repository implements Countable, IteratorAggregate, JsonSerializable
         if (! is_array($dataItems)) {
             throw new RuntimeException('JSON decoded contents from %s is not an array');
         }
+
+        $itemFactory = new RepositoryItemFactory();
         $items = [];
         foreach ($dataItems as $index => $dataItem) {
             if (! is_array($dataItem)) {
                 throw new RuntimeException("Entry $index is not an array");
             }
-            $item = RepositoryItem::fromArray($dataItem);
+            $item = $itemFactory->make($dataItem);
             $items[$item->getUuid()] = $item;
         }
         return new self($items);

--- a/tests/Integration/RepositoryItem.php
+++ b/tests/Integration/RepositoryItem.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
 
 use DateTimeImmutable;
-use DomainException;
-use Exception;
 use JsonSerializable;
 
 class RepositoryItem implements JsonSerializable
@@ -29,26 +27,6 @@ class RepositoryItem implements JsonSerializable
         $this->date = $date;
         $this->type = strtoupper(substr($type, 0, 1));
         $this->state = strtoupper(substr($state, 0, 1));
-    }
-
-    /** @param array<mixed> $item */
-    public static function fromArray(array $item): self
-    {
-        return new self(
-            strval($item['uuid'] ?? ''),
-            self::dateFromString(strval($item['date'] ?? '')),
-            strval($item['state'] ?? ''),
-            strval($item['type'] ?? ''),
-        );
-    }
-
-    private static function dateFromString(string $value): DateTimeImmutable
-    {
-        try {
-            return new DateTimeImmutable($value);
-        } catch (Exception $exception) {
-            throw new DomainException(sprintf('Unable to parse date with value %s', $value));
-        }
     }
 
     public function getUuid(): string

--- a/tests/Integration/RepositoryItemFactory.php
+++ b/tests/Integration/RepositoryItemFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Integration;
+
+use DateTimeImmutable;
+use DomainException;
+use Exception;
+
+class RepositoryItemFactory
+{
+    /** @param array<mixed> $values */
+    public function make(array $values): RepositoryItem
+    {
+        $maker = new self();
+        return new RepositoryItem(
+            $maker->stringFromValues($values, 'uuid'),
+            $maker->dateFromString($maker->stringFromValues($values, 'date')),
+            $maker->stringFromValues($values, 'state'),
+            $maker->stringFromValues($values, 'type'),
+        );
+    }
+
+    /** @param array<mixed> $values */
+    private function stringFromValues(array $values, string $key): string
+    {
+        if (! isset($values[$key]) || ! is_string($values[$key])) {
+            throw new DomainException(sprintf('Cannot create an entry with invalid %s', $key));
+        }
+        return $values[$key];
+    }
+
+    private function dateFromString(string $value): DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $exception) {
+            throw new DomainException(sprintf('Unable to parse date with value %s', $value));
+        }
+    }
+}

--- a/tests/Unit/Exceptions/ResourceDownloadResponseErrorTest.php
+++ b/tests/Unit/Exceptions/ResourceDownloadResponseErrorTest.php
@@ -23,7 +23,7 @@ final class ResourceDownloadResponseErrorTest extends TestCase
     {
         /** @var ResponseInterface&MockObject $response */
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getStatusCode')->willReturn('503');
+        $response->method('getStatusCode')->willReturn(503);
         $uuid = 'uuid';
         $exception = ResourceDownloadResponseError::invalidStatusCode($response, $uuid);
         $this->assertSame(


### PR DESCRIPTION
Estos cambios se realizan en el entorno de desarrollo y pruebas, por lo que no es necesario hacer una liberación.

- Se refactoriza la clase `RepositoryItem` para que las responsabilidades de la creación de una instancia a partir de un arreglo se realizen en la clase `RepositoryItemFactory`.
- Se corrige el issue falso positivo encontrado por PHPStan al convertir un objeto a cadena de caracteres.
- Actualización de herramientas de desarrollo.
