### PR TITLE
Revisión 2023-06-22, correcciones menores (Versión 3.2.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "main" ]
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,23 @@ jobs:
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
 
+  composer-normalize:
+    name: Composer normalization
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          tools: composer-normalize
+        env:
+          fail-fast: true
+      - name: Composer normalize
+        run: composer-normalize
+
   phpstan:
     name: Code analysis (phpstan)
     runs-on: "ubuntu-latest"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,6 @@ jobs:
           fail-fast: true
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: y
 
   phpstan:
     name: Code analysis (phpstan)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,6 @@
 name: coverage
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   tests-coverage:
-    name: Tests on PHP 8.1 (code coverage)
+    name: Tests on PHP 8.2 (code coverage)
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: xdebug
           tools: composer:v2
         env:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -4,4 +4,5 @@
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^1.10.21" installed="1.10.21" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.31.0" installed="2.31.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.17.0" installed="3.17.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.18.0" installed="3.18.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.15" installed="1.10.15" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.10.21" installed="1.10.21" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribuciones
 
-Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][homepage].
+Las contribuciones son bienvenidas. Aceptamos *Pull Requests* en el [repositorio GitHub][project].
 
 Este proyecto se apega al siguiente [Código de Conducta][coc].
 Al participar en este proyecto y en su comunidad, deberás seguir este código.

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,14 @@
 {
     "name": "phpcfdi/cfdi-sat-scraper",
-    "type": "library",
     "description": "Web Scraping para extraer facturas electrónicas desde la página del SAT",
-    "keywords": ["sat", "cfdi", "scrap", "mexico"],
     "license": "MIT",
+    "type": "library",
+    "keywords": [
+        "sat",
+        "cfdi",
+        "scrap",
+        "mexico"
+    ],
     "authors": [
         {
             "name": "Cesar Aguilera",
@@ -14,14 +19,29 @@
             "email": "eclipxe13@gmail.com"
         }
     ],
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": false
-        },
-        "preferred-install": {
-            "*": "dist"
-        },
-        "optimize-autoloader": true
+    "require": {
+        "php": ">=7.3",
+        "ext-curl": "*",
+        "ext-dom": "*",
+        "ext-fileinfo": "*",
+        "ext-json": "*",
+        "ext-mbstring": "*",
+        "ext-openssl": "*",
+        "eclipxe/enum": "^0.2.0",
+        "eclipxe/micro-catalog": "^v0.1.3",
+        "guzzlehttp/guzzle": "^7.0",
+        "guzzlehttp/promises": "^2.0",
+        "phpcfdi/credentials": "^1.1",
+        "phpcfdi/image-captcha-resolver": "^0.2.3",
+        "psr/http-message": "^1.1 || ^2.0",
+        "symfony/css-selector": "^5.4 || ^6.0",
+        "symfony/dom-crawler": "^5.4 || ^6.0"
+    },
+    "require-dev": {
+        "ext-iconv": "*",
+        "fakerphp/faker": "^1.13",
+        "phpunit/phpunit": "^9.5",
+        "symfony/dotenv": "^5.4 || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -33,29 +53,14 @@
             "PhpCfdi\\CfdiSatScraper\\Tests\\": "tests"
         }
     },
-    "require": {
-        "php": ">=7.3",
-        "ext-curl": "*",
-        "ext-dom": "*",
-        "ext-json": "*",
-        "ext-fileinfo": "*",
-        "ext-mbstring": "*",
-        "ext-openssl": "*",
-        "psr/http-message": "^1.1|^2.0",
-        "guzzlehttp/guzzle": "^7.0",
-        "guzzlehttp/promises": "^2.0",
-        "symfony/dom-crawler": "^5.4|^6.0",
-        "symfony/css-selector": "^5.4|^6.0",
-        "eclipxe/enum": "^0.2.0",
-        "eclipxe/micro-catalog": "^v0.1.3",
-        "phpcfdi/credentials": "^1.1",
-        "phpcfdi/image-captcha-resolver": "^0.2.3"
-    },
-    "require-dev": {
-        "ext-iconv": "*",
-        "phpunit/phpunit": "^9.5",
-        "symfony/dotenv": "^5.4|^6.0",
-        "fakerphp/faker": "^1.13"
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        },
+        "optimize-autoloader": true,
+        "preferred-install": {
+            "*": "dist"
+        }
     },
     "scripts": {
         "dev:build": [

--- a/composer.json
+++ b/composer.json
@@ -63,10 +63,12 @@
             "@dev:tests"
         ],
         "dev:check-style": [
+            "@php tools/composer-normalize normalize --dry-run",
             "@php -r 'exit(intval(PHP_VERSION_ID >= 74000));' || $PHP_BINARY tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
+            "@php tools/composer-normalize normalize",
             "@php -r 'exit(intval(PHP_VERSION_ID >= 74000));' || $PHP_BINARY tools/php-cs-fixer fix --verbose",
             "@php tools/phpcbf --colors -sp"
         ],
@@ -78,8 +80,8 @@
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
-        "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
-        "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
+        "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
         "dev:tests": "DEV: run executes phpunit tests"
     }
 }

--- a/develop/ComoFunciona.md
+++ b/develop/ComoFunciona.md
@@ -6,7 +6,7 @@ Al `SatScraper` se le pide que ejecute consultas, de las que hay dos definicione
 
 La propiedad que comparten todas las consultas es `DownloadType`, que define si se trata de *recibidos* o *emitidos*.
 
-Tanto en *recibidos* o *emitidos* se puede consultar por *UUID* o por *filtros*. Por lo tanto hay 4 tipos de consultas:
+Tanto en *recibidos* o *emitidos* se puede consultar por *UUID* o por *filtros*. Por lo tanto, hay 4 tipos de consultas:
 Recibidos por UUID, Recibidos por filtros, Emitidos por UUID y Emitidos por filtros.
 Sin embargo, se simplifica porque el portal del SAT funciona casi igual para recibidos y emitidos, por lo que se puede
 reducir a 3 tipos: Por UUID (recibidos/emitidos), Recibidos por filtro, Emitidos por filtro.
@@ -37,9 +37,9 @@ encargado de definir cuál es la implementación de `InputsInterface` que utiliz
 La resolución de una consulta de `QueryResolver` consta de 3 pasos:
 
 1. Entrar a la página principal según el tipo de consulta (recibidos o emitidos) y obtener todos los inputs.
-1. Hacer la selección del tipo de consulta (por UUID o por filtros) y recapturar los inputs que hubieran cambiado.
-1. Hacer la consulta con los datos específicos (uuid, fechas, rfc, complemento, estado, etc.)
-1. Generar el objeto `MetadataList` a partir de los datos devueltos.
+2. Hacer la selección del tipo de consulta (por UUID o por filtros) y recapturar los inputs que hubieran cambiado.
+3. Hacer la consulta con los datos específicos (uuid, fechas, rfc, complemento, estado, etc.)
+4. Generar el objeto `MetadataList` a partir de los datos devueltos.
 
 Por lo anterior, los pasos son:
 

--- a/develop/EntornoDesarrollo.md
+++ b/develop/EntornoDesarrollo.md
@@ -25,7 +25,7 @@ Un buen paso podría ser iniciar ejecutando los tests unitarios
 vendor/bin/phpunit tests/Unit --testdox --verbose
 ```
 
-Y después los tests de integración, sin embargo es probable que necesites configurar el archivo `tests/.env`.
+Y después los tests de integración, sin embargo, es probable que necesites configurar el archivo `tests/.env`.
 Revisa la información en [TestIntegracion](TestIntegracion.md)
 
 ```shell

--- a/develop/TestIntegracion.md
+++ b/develop/TestIntegracion.md
@@ -1,6 +1,6 @@
 # Test de integración
 
-Las pruebas de integración realizan consultas al sitio web del SAT y por lo tanto,
+Las pruebas de integración realizan consultas al sitio web del SAT y, por lo tanto,
 como utiliza datos de RFC y Clave CIEC, o bien, utiliza la llave FIEL,
 entonces no pueden funcionar igual para todos.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,24 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
+## Versión 3.2.4 2023-06-22
+
+Se corrige el mensaje relacionado con el envío de datos incorrectos al iniciar sesión usando CIEC.
+
+Se corrige la dependencia de `CaptchaImage` por `CaptchaImageInterface` en `CiecLoginException`.
+
+Se extrae la lógica para hacer la petición de acceso vía CIEC a un método separado.
+En una prueba de concepto esto ayuda a crear la sesión usando un valor conocido de *Captcha*.
+
+Se agregan los siguientes cambios en el entorno de desarrollo:
+
+- Se corrige la liga del proyecto en el archivo `CONTRIBUTING.md`.
+- Se actualizan las herramientas de desarrollo.
+- Se agrega la herramienta `composer-normalize`.
+- En el flujo de trabajo de cobertura de código se ejecuta usando PHP 8.2.
+- Se elimina `PHP_CS_FIXER_IGNORE_ENV` del flujo de trabajo principal en el trabajo `php-cs-fixer`.
+- Se agrega la opción para ejecutar flujos de trabajo a solicitud.
+
 ### Cambios no liberados: 2023-02-13
 
 - Se corrige la configuración de `sonar-project.properties` para excluir correctamente los archivos para pruebas.

--- a/docs/EjemploConsumo.md
+++ b/docs/EjemploConsumo.md
@@ -12,7 +12,7 @@ Y se espera que:
 
 - Se pueda reutilizar la `cookie` si no ha expirado y así no tener que volver a resolver un captcha.
 - Se carge una lista de CFDI recibidos y vigentes entre 2019-12-01 y 2019-12-31.
-- Se descarguen los XML correspondientes a dichos registros.
+- Ocurra la descarga de los XML correspondientes a dichos registros.
 
 La rutina de descarga intentará hasta que haya descargado todos los archivos.
 

--- a/src/Sessions/Ciec/CiecLoginException.php
+++ b/src/Sessions/Ciec/CiecLoginException.php
@@ -62,7 +62,7 @@ class CiecLoginException extends LoginException
      */
     public static function incorrectLoginData(CiecSessionData $data, string $contents, array $postedData): self
     {
-        return new self('Unable to decode captcha', $data, $contents, $postedData);
+        return new self('Incorrect login data', $data, $contents, $postedData);
     }
 
     public static function connectionException(string $when, CiecSessionData $data, SatHttpGatewayException $exception): self

--- a/src/Sessions/Ciec/CiecLoginException.php
+++ b/src/Sessions/Ciec/CiecLoginException.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\CfdiSatScraper\Sessions\Ciec;
 
 use PhpCfdi\CfdiSatScraper\Exceptions\LoginException;
 use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayException;
-use PhpCfdi\ImageCaptchaResolver\CaptchaImage;
+use PhpCfdi\ImageCaptchaResolver\CaptchaImageInterface;
 use Throwable;
 
 class CiecLoginException extends LoginException
@@ -17,7 +17,7 @@ class CiecLoginException extends LoginException
     /** @var array<string, string> */
     private $postedData;
 
-    /** @var CaptchaImage|null */
+    /** @var CaptchaImageInterface|null */
     private $captchaImage;
 
     /**
@@ -47,7 +47,7 @@ class CiecLoginException extends LoginException
         return new self('It was unable to find the captcha image', $data, $contents, [], $previous);
     }
 
-    public static function captchaWithoutAnswer(CiecSessionData $data, CaptchaImage $captchaImage, Throwable $previous = null): self
+    public static function captchaWithoutAnswer(CiecSessionData $data, CaptchaImageInterface $captchaImage, Throwable $previous = null): self
     {
         $exception = new self('Unable to decode captcha', $data, '', [], $previous);
         $exception->captchaImage = $captchaImage;
@@ -81,7 +81,7 @@ class CiecLoginException extends LoginException
         return $this->postedData;
     }
 
-    public function getCaptchaImage(): ?CaptchaImage
+    public function getCaptchaImage(): ?CaptchaImageInterface
     {
         return $this->captchaImage;
     }

--- a/tests/Unit/Sessions/Ciec/CiecLoginExceptionTest.php
+++ b/tests/Unit/Sessions/Ciec/CiecLoginExceptionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\CfdiSatScraper\Tests\Unit\Sessions\Ciec;
+
+use Exception;
+use PhpCfdi\CfdiSatScraper\Exceptions\SatHttpGatewayClientException;
+use PhpCfdi\CfdiSatScraper\Sessions\Ciec\CiecLoginException;
+use PhpCfdi\CfdiSatScraper\Sessions\Ciec\CiecSessionData;
+use PhpCfdi\CfdiSatScraper\Tests\TestCase;
+use PhpCfdi\ImageCaptchaResolver\CaptchaImageInterface;
+
+final class CiecLoginExceptionTest extends TestCase
+{
+    public function testNotRegisteredAfterLogin(): void
+    {
+        /** @var CiecSessionData $sessionData */
+        $sessionData = $this->createMock(CiecSessionData::class);
+        $contents = 'x-contents';
+
+        $exception = CiecLoginException::notRegisteredAfterLogin($sessionData, $contents);
+
+        $this->assertStringContainsString(
+            'It was expected to have the session registered on portal home page with RFC',
+            $exception->getMessage(),
+        );
+        $this->assertSame($sessionData, $exception->getSessionData());
+        $this->assertSame($contents, $exception->getContents());
+    }
+
+    public function testNoCaptchaImageFound(): void
+    {
+        /** @var CiecSessionData $sessionData */
+        $sessionData = $this->createMock(CiecSessionData::class);
+        $contents = 'x-contents';
+        $previous = new Exception('previous');
+
+        $exception = CiecLoginException::noCaptchaImageFound($sessionData, $contents, $previous);
+
+        $this->assertStringContainsString('It was unable to find the captcha image', $exception->getMessage());
+        $this->assertSame($sessionData, $exception->getSessionData());
+        $this->assertSame($contents, $exception->getContents());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testCaptchaWithoutAnswer(): void
+    {
+        /** @var CiecSessionData $sessionData */
+        $sessionData = $this->createMock(CiecSessionData::class);
+        /** @var CaptchaImageInterface $captchaImage */
+        $captchaImage = $this->createMock(CaptchaImageInterface::class);
+        $previous = new Exception('previous');
+
+        $exception = CiecLoginException::captchaWithoutAnswer($sessionData, $captchaImage, $previous);
+
+        $this->assertStringContainsString('Unable to decode captcha', $exception->getMessage());
+        $this->assertSame($sessionData, $exception->getSessionData());
+        $this->assertSame($captchaImage, $exception->getCaptchaImage());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+
+    public function testIncorrectLoginData(): void
+    {
+        /** @var CiecSessionData $sessionData */
+        $sessionData = $this->createMock(CiecSessionData::class);
+        $contents = 'x-contents';
+        $postedData = [];
+
+        $exception = CiecLoginException::incorrectLoginData($sessionData, $contents, $postedData);
+
+        $this->assertStringContainsString('Incorrect login data', $exception->getMessage());
+        $this->assertSame($sessionData, $exception->getSessionData());
+        $this->assertSame($contents, $exception->getContents());
+        $this->assertSame($postedData, $exception->getPostedData());
+    }
+
+    public function testConnectionException(): void
+    {
+        $when = 'x-when';
+        /** @var CiecSessionData $sessionData */
+        $sessionData = $this->createMock(CiecSessionData::class);
+        /** @var SatHttpGatewayClientException $previous */
+        $previous = $this->createMock(SatHttpGatewayClientException::class);
+
+        $exception = CiecLoginException::connectionException($when, $sessionData, $previous);
+
+        $this->assertStringContainsString("Connection error when $when", $exception->getMessage());
+        $this->assertSame($sessionData, $exception->getSessionData());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}


### PR DESCRIPTION
Se corrige el mensaje relacionado con el envío de datos incorrectos al iniciar sesión usando CIEC.

Se corrige la dependencia de `CaptchaImage` por `CaptchaImageInterface` en `CiecLoginException`.

Se extrae la lógica para hacer la petición de acceso vía CIEC a un método separado.
En una prueba de concepto esto ayuda a crear la sesión usando un valor conocido de *Captcha*.

Se agregan los siguientes cambios en el entorno de desarrollo:

- Se corrige la liga del proyecto en el archivo `CONTRIBUTING.md`.
- Se actualizan las herramientas de desarrollo.
- Se agrega la herramienta `composer-normalize`.
- En el flujo de trabajo de cobertura de código se ejecuta usando PHP 8.2.
- Se elimina `PHP_CS_FIXER_IGNORE_ENV` del flujo de trabajo principal en el trabajo `php-cs-fixer`.
- Se agrega la opción para ejecutar flujos de trabajo a solicitud.