### PR TITLE
Fix catching wrong exception (Version 3.2.5)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.18.0" installed="3.18.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.20.0" installed="3.20.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.21" installed="1.10.21" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.31.0" installed="2.31.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpstan" version="^1.10.22" installed="1.10.22" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.32.0" installed="2.32.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 Algunos métodos intentaban atrapar una excepción `RuntimeException` proveniente de `Crawler`, sin embargo, 
 la excepción no era correcta, se atrapa ahora `Throwable`. Gracias a PHPStan por detectar el problema.
 
+Se actualizan las dependencias de desarrollo.
+
 ## Versión 3.2.4 2023-06-22
 
 Se corrige el mensaje relacionado con el envío de datos incorrectos al iniciar sesión usando CIEC.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
+## Versión 3.2.5 2023-07-03
+
+Algunos métodos intentaban atrapar una excepción `RuntimeException` proveniente de `Crawler`, sin embargo, 
+la excepción no era correcta, se atrapa ahora `Throwable`. Gracias a PHPStan por detectar el problema.
+
 ## Versión 3.2.4 2023-06-22
 
 Se corrige el mensaje relacionado con el envío de datos incorrectos al iniciar sesión usando CIEC.

--- a/src/Internal/HtmlForm.php
+++ b/src/Internal/HtmlForm.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace PhpCfdi\CfdiSatScraper\Internal;
 
 use DOMElement;
-use RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
+use Throwable;
 
 /**
  * Utility class to extract data from an HTML form.
@@ -166,7 +166,7 @@ class HtmlForm
     {
         try {
             $elements = $this->crawler->filter($filter);
-        } catch (RuntimeException $exception) {
+        } catch (Throwable $exception) {
             $elements = [];
         }
         /** @var Crawler|DOMElement[] $elements */

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -10,6 +10,7 @@ use PhpCfdi\CfdiSatScraper\ResourceType;
 use PhpCfdi\CfdiSatScraper\URLS;
 use RuntimeException;
 use Symfony\Component\DomCrawler\Crawler;
+use Throwable;
 
 /**
  * Parses a web page to obtain all the Metadata records on it.
@@ -182,7 +183,7 @@ class MetadataExtractor
     {
         try {
             $filteredElements = $crawler->filter($elementFilter);
-        } catch (RuntimeException $exception) {
+        } catch (Throwable $exception) {
             return '';
         }
 


### PR DESCRIPTION
Fix catching crawler exception:
    - class HtmlForm (internal) method filterCrawlerElements.
    - class MetadataExtractor (internal) method obtainOnClickFromElement.
Thanks PHPStan!

Update development tools