### PR TITLE
Mantenimiento 2024-05-22 (versión 3.3.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -35,7 +35,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -69,7 +69,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -82,7 +82,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -100,7 +100,7 @@ jobs:
         php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -113,7 +113,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
@@ -116,7 +116,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: "${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}"
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,14 +97,14 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-version: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: none
           tools: composer:v2
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -28,7 +28,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -38,7 +38,7 @@ jobs:
       - name: Create code coverage
         run: vendor/bin/phpunit --testsuite=complete --testdox --verbose --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
       - name: Store code coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage
           path: build/coverage
@@ -73,7 +73,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Unshallow clone to provide blame information
         run: git fetch --unshallow
       - name: Setup PHP
@@ -86,7 +86,7 @@ jobs:
         id: composer-cache
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -94,7 +94,7 @@ jobs:
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Obtain code coverage
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: code-coverage
           path: build/coverage

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.40.0" installed="3.40.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.46" installed="1.10.46" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.39.0" installed="2.39.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.57.2" installed="3.57.2" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.10.0" installed="3.10.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.10.0" installed="3.10.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.11.11" installed="1.11.1" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/composer.json
+++ b/composer.json
@@ -34,14 +34,14 @@
         "phpcfdi/credentials": "^1.1",
         "phpcfdi/image-captcha-resolver": "^0.2.3",
         "psr/http-message": "^1.1 || ^2.0",
-        "symfony/css-selector": "^5.4 || ^6.0",
-        "symfony/dom-crawler": "^5.4 || ^6.0"
+        "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dom-crawler": "^5.4 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-iconv": "*",
         "fakerphp/faker": "^1.13",
         "phpunit/phpunit": "^9.5",
-        "symfony/dotenv": "^5.4 || ^6.0"
+        "symfony/dotenv": "^5.4 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "eclipxe/enum": "^0.2.0",
-        "eclipxe/micro-catalog": "^v0.1.3",
+        "eclipxe/micro-catalog": "^0.1.3",
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/promises": "^2.0",
         "phpcfdi/credentials": "^1.1",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,14 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
+## Versión 3.3.1 2024-05-22
+
+- PHPStan encontró un problema en una especificación de tipo en un método de prueba,
+  se ha corregido solo para que el proceso de integración continua no falle.
+- Se actualizan las dependencias de los componentes de Symfony para soportar la versión 7.
+- Se actualizan los flujos de trabajo de GitHub para usar las acciones versión 4.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 3.3.0 2023-12-03
 
 Se agregó la interfaz `MetadataMessageHandler` que permite recibir notificaciones de la descarga de *Metadata*.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
   se ha corregido solo para que el proceso de integración continua no falle.
 - Se actualizan las dependencias de los componentes de Symfony para soportar la versión 7.
 - Se actualizan los flujos de trabajo de GitHub para usar las acciones versión 4.
+- Se usa `php-version` en singular, en lugar de `php-versions`.
 - Se actualizan las herramientas de desarrollo.
 
 ## Versión 3.3.0 2023-12-03

--- a/tests/Integration/HttpLogger.php
+++ b/tests/Integration/HttpLogger.php
@@ -110,7 +110,7 @@ class HttpLogger extends ArrayObject
 
     /**
      * @param string $body
-     * @return array<string|array<string>>
+     * @return array<mixed>
      */
     public function bodyToVars(string $body): array
     {


### PR DESCRIPTION
- PHPStan encontró un problema en una especificación de tipo en un método de prueba, se ha corregido solo para que el proceso de integración continua no falle.
- Se actualizan las dependencias de los componentes de Symfony para soportar la versión 7.
- Se actualizan los flujos de trabajo de GitHub para usar las acciones versión 4.
- Se usa `php-version` en singular, en lugar de `php-versions`.
- Se actualizan las herramientas de desarrollo.