### PR TITLE
Mantenimiento 2024-09-09 (Versión 3.3.2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.57.2" installed="3.57.2" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.10.0" installed="3.10.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.10.0" installed="3.10.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.11.11" installed="1.11.1" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.42.0" installed="2.42.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.64.0" installed="3.64.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.10.2" installed="3.10.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.10.2" installed="3.10.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.12.3" installed="1.12.3" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.43.0" installed="2.43.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2024 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 ## Versión 3.3.2 2024-09-09
 
 - PHPStan encontró una comparación superflua que fue eliminada para corregir el proceso de integración continua.
+- Se agregan comentarios a clases *Null* para mejorar la manentibilidad.
 - Se actualiza el año del archivo de licencia a 2024.
 - Se actualizan las herramientas de desarrollo.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 - PHPStan encontró una comparación superflua que fue eliminada para corregir el proceso de integración continua.
 - Se agregan comentarios a clases *Null* para mejorar la manentibilidad.
 - Se actualiza el año del archivo de licencia a 2024.
+- Se corrige la variable `php-versions` por `php-version` en el flujo de trabajo `tests`.
 - Se actualizan las herramientas de desarrollo.
 
 ## Versión 3.3.1 2024-05-22

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,12 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 ## Cambios aún no liberados en una versión
 
+## Versión 3.3.2 2024-09-09
+
+- PHPStan encontró una comparación superflua que fue eliminada para corregir el proceso de integración continua.
+- Se actualiza el año del archivo de licencia a 2024.
+- Se actualizan las herramientas de desarrollo.
+
 ## Versión 3.3.1 2024-05-22
 
 - PHPStan encontró un problema en una especificación de tipo en un método de prueba,

--- a/src/Internal/MetaRefreshInspector.php
+++ b/src/Internal/MetaRefreshInspector.php
@@ -28,7 +28,7 @@ final class MetaRefreshInspector
             return '';
         }
 
-        $url = trim($matches['url'] ?? '');
+        $url = trim($matches['url']);
         if ('' === $url) {
             return '';
         }

--- a/src/NullMetadataMessageHandler.php
+++ b/src/NullMetadataMessageHandler.php
@@ -10,17 +10,21 @@ class NullMetadataMessageHandler implements Contracts\MetadataMessageHandler
 {
     public function resolved(DateTimeImmutable $since, DateTimeImmutable $until, int $count): void
     {
+        // null object, do nothing
     }
 
     public function date(DateTimeImmutable $since, DateTimeImmutable $until, int $count): void
     {
+        // null object, do nothing
     }
 
     public function divide(DateTimeImmutable $since, DateTimeImmutable $until): void
     {
+        // null object, do nothing
     }
 
     public function maximum(DateTimeImmutable $moment): void
     {
+        // null object, do nothing
     }
 }


### PR DESCRIPTION
- PHPStan encontró una comparación superflua que fue eliminada para corregir el proceso de integración continua.
- Se actualiza el año del archivo de licencia a 2024.
- Se actualizan las herramientas de desarrollo.
