### PR TITLE
Corregir los problemas con `symfony/dom-crawler issues` versiones `7.4+` ó `8.0+` (version 5.0.3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           fail-fast: true
       - name: Composer normalize
-        run: composer-normalize
+        run: composer-normalize --dry-run
 
   phpcs:
     name: Code style (phpcs)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.87.2" installed="3.88.2" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^4.0.0" installed="4.0.0" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^4.0.0" installed="4.0.0" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^2.1.25" installed="2.1.29" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.91.3" installed="3.91.3" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="4.0.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="4.0.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.33" installed="2.1.33" location="./tools/phpstan" copy="false"/>
   <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,8 +15,8 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP8x2Migration:risky' => true,
         '@PHP8x2Migration' => true,
+        '@PHP8x2Migration:risky' => true,
         // symfony
         'array_indentation' => true,
         'class_attributes_separation' => true,
@@ -24,7 +24,7 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'type_declaration_spaces' => true,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays', 'match', 'arguments', 'parameters']],
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match', 'arguments', 'parameters']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,8 @@
         "phpcfdi/credentials": "^1.1",
         "phpcfdi/image-captcha-resolver": "^0.3.0",
         "psr/http-message": "^1.1 || ^2.0",
-        "symfony/css-selector": "^5.4 || ^6.0 || ^7.0",
-        "symfony/dom-crawler": "^5.4 || ^6.0 || ^7.0"
+        "symfony/css-selector": "^7.4 || ^8.0",
+        "symfony/dom-crawler": "^7.4 || ^8.0"
     },
     "require-dev": {
         "ext-iconv": "*",

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
         "phpunit/phpunit": "^11.5",
         "symfony/dotenv": "^5.4 || ^6.0 || ^7.0"
     },
+    "suggest": {
+        "phpcfdi/image-captcha-resolver-boxfactura-ai": "Permite resolver los captchas localmente con inteligencia artificial"
+    },
     "autoload": {
         "psr-4": {
             "PhpCfdi\\CfdiSatScraper\\": "src"
@@ -91,8 +94,5 @@
         "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
         "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
         "dev:tests": "DEV: run executes phpunit tests"
-    },
-    "suggest": {
-        "phpcfdi/image-captcha-resolver-boxfactura-ai": "Permite resolver los captchas localmente con inteligencia artificial"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -57,8 +57,8 @@ Esta versión libera un cambio mayor provocado por el cambio de columnas que imp
 
 En la información de *Metadata* se ajusta la información a la nueva estructura de datos del SAT:
 
-- Ya no existe `fechaProcesoCancelacion`. 
-- Se agrega `fechaSolicitudCancelacion`. 
+- Ya no existe `fechaProcesoCancelacion`.
+- Se agrega `fechaSolicitudCancelacion`.
 - Se agrega `fechaDeCancelacion`.
 
 Gracias totales a `@cruzcraul` por notar este cambio y la implementación.
@@ -164,7 +164,7 @@ Se agregan los siguientes cambios en el entorno de desarrollo:
 - Se elimina `PHP_CS_FIXER_IGNORE_ENV` del flujo de trabajo principal en el trabajo `php-cs-fixer`.
 - Se agrega la opción para ejecutar flujos de trabajo a solicitud.
 
-### Cambios no liberados: 2023-02-13
+### Cambios no liberados: 2023-06-13
 
 - Se corrige la configuración de `sonar-project.properties` para excluir correctamente los archivos para pruebas.
 - Se excluye correctamente el archivo `sonar-project.properties` del paquete de Git.
@@ -278,7 +278,7 @@ Se mejoran los test para probar valores idénticos en lugar de valores iguales.
 
 Se actualizan las herramientas de desarrollo.
 
-Se actualiza el archivo de configuración de `php-cs-fixer`. 
+Se actualiza el archivo de configuración de `php-cs-fixer`.
 
 ## Versión 3.1.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,18 @@ Usamos [Versionado Semántico 2.0.0](SEMVER.md) por lo que puedes usar esta libr
 
 No existen cambios aún no liberados en una versión.
 
+## Versión 5.0.3 2025-12-12
+
+- Se cambian las dependencias de Symfony a la versión `7.4+` ó `8.0+`.
+- Se corrigen las expresiones XPath, pues ahora el resultado de *DomCrawler* se basa en
+  el intérprete interno de PHP para HTML5 en lugar de `masterminds/html5`.
+
+### Entorno de desarrollo
+
+- Se agrega PHP 8.5 a la matriz de pruebas.
+- Se corrige el trabajo `composer-normalize` para que falle como es esperado.
+- Se actualizaron las herramientas de desarrollo.
+
 ## Versión 5.0.2 2025-10-29
 
 - Se corrige en `composer.json` la sección `suggest` que tenía el nombre `recommended`.

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -29,7 +29,9 @@ class MetadataExtractor
         }
 
         try {
-            $rows = (new Crawler($html))->filter('table#ctl00_MainContent_tblResult > tbody > tr');
+            $rows = (new Crawler($html))->filter(
+                'table#ctl00_MainContent_tblResult > tbody > tr , table#ctl00_MainContent_tblResult > tr'
+            );
         } catch (RuntimeException) {
             return new MetadataList([]);
         }

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -30,7 +30,7 @@ class MetadataExtractor
 
         try {
             $rows = (new Crawler($html))->filter(
-                'table#ctl00_MainContent_tblResult > tbody > tr , table#ctl00_MainContent_tblResult > tr'
+                'table#ctl00_MainContent_tblResult > tbody > tr , table#ctl00_MainContent_tblResult > tr',
             );
         } catch (RuntimeException) {
             return new MetadataList([]);

--- a/src/Internal/MetadataExtractor.php
+++ b/src/Internal/MetadataExtractor.php
@@ -29,7 +29,7 @@ class MetadataExtractor
         }
 
         try {
-            $rows = (new Crawler($html))->filter('table#ctl00_MainContent_tblResult > tr');
+            $rows = (new Crawler($html))->filter('table#ctl00_MainContent_tblResult > tbody > tr');
         } catch (RuntimeException) {
             return new MetadataList([]);
         }

--- a/tests/Unit/Internal/HtmlFormTest.php
+++ b/tests/Unit/Internal/HtmlFormTest.php
@@ -142,7 +142,7 @@ final class HtmlFormTest extends TestCase
         $form = '<form>';
         $form .= '<input name="foo" type="radio" value="1">';
         $form .= '<input name="foo" type="radio" value="2" checked="checked">';
-        $form .= '<input name="bar" type="radio" value="1" checked>';
+        $form .= '<input name="bar" type="radio" value="1" checked="checked">';
         $form .= '<input name="bar" type="radio" value="2">';
         $form .= '</form>';
 

--- a/tests/Unit/Internal/MetadataExtractorTest.php
+++ b/tests/Unit/Internal/MetadataExtractorTest.php
@@ -20,7 +20,7 @@ final class MetadataExtractorTest extends TestCase
         ];
 
         $firstRow = (new Crawler(
-            '<tr><th>Alpha</th><th>Folio Fiscal</th><th>RFC Emisor</th></tr>',
+            '<table><tr><th>Alpha</th><th>Folio Fiscal</th><th>RFC Emisor</th></tr></table>',
         ))->filter('tr')->first();
         $extractor = new MetadataExtractor();
         $fieldsPositions = $extractor->locateFieldsPositions($firstRow, $fieldsCaptions);
@@ -41,7 +41,7 @@ final class MetadataExtractorTest extends TestCase
         ];
 
         $row = (new Crawler(
-            '<tr><td>Alpha</td><td>Bravo</td><td>Charlie</td><td>Delta</td><td>Echo</td></tr>',
+            '<table><tr><td>Alpha</td><td>Bravo</td><td>Charlie</td><td>Delta</td><td>Echo</td></tr></table>',
         ))->filter('tr')->first();
         $extractor = new MetadataExtractor();
         $values = $extractor->obtainMetadataValues($row, $fieldsPositions);
@@ -56,7 +56,7 @@ final class MetadataExtractorTest extends TestCase
 
     public function testObtainMetadataValuesWithEmptyRow(): void
     {
-        $row = (new Crawler('<tr></tr>'))->filter('tr')->first();
+        $row = (new Crawler('<table><tr></tr></table>'))->filter('tr')->first();
         $extractor = new MetadataExtractor();
         $values = $extractor->obtainMetadataValues($row, ['uuid' => 1]);
         $this->assertArrayHasKey('uuid', $values);
@@ -65,7 +65,7 @@ final class MetadataExtractorTest extends TestCase
 
     public function testObtainUrlWithoutButton(): void
     {
-        $row = (new Crawler('<tr></tr>'))->filter('tr')->first();
+        $row = (new Crawler('<table><tr></tr></table>'))->filter('tr')->first();
         $extractor = new MetadataExtractor();
         $this->assertEmpty($extractor->obtainUrlXml($row));
     }


### PR DESCRIPTION
- Se cambian las dependencias de Symfony a la versión `7.4+` ó `8.0+`.
- Se corrigen las expresiones XPath, pues ahora el resultado de *DomCrawler* se basa en
  el intérprete interno de PHP para HTML5 en lugar de `masterminds/html5`.

### Entorno de desarrollo

- Se agrega PHP 8.5 a la matriz de pruebas.
- Se corrige el trabajo `composer-normalize` para que falle como es esperado.
- Se actualizaron las herramientas de desarrollo.
